### PR TITLE
fix: prevent agents from returning pre-tool text as the final answer

### DIFF
--- a/scripts/e2e_smoke_test.py
+++ b/scripts/e2e_smoke_test.py
@@ -27,7 +27,6 @@ Requirements:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import shutil
 import signal

--- a/scripts/regenerate_fixtures.py
+++ b/scripts/regenerate_fixtures.py
@@ -192,7 +192,6 @@ def _interpolate_template_vars(text: str, entities: dict[str, list[dict]]) -> st
 def generate_traces(client: anthropic.Anthropic, ontology, entities: dict) -> list[dict]:
     """Generate complete decision traces with realistic observations and outcomes."""
     traces = []
-    import random
 
     for trace_def in ontology.decision_traces:
         # Interpolate entity references into task
@@ -350,13 +349,13 @@ def regenerate_domain(client: anthropic.Anthropic, domain_id: str) -> dict | Non
             entity_count = sum(len(v) for v in entities.values())
             print(f"  Generated {entity_count} entities across {len(entities)} types")
 
-            print(f"  Weaving relationships...")
+            print("  Weaving relationships...")
             relationships = weave_relationships(ontology, entities)
 
-            print(f"  Generating documents...")
+            print("  Generating documents...")
             documents = generate_documents(client, ontology, entities)
 
-            print(f"  Generating decision traces...")
+            print("  Generating decision traces...")
             traces = generate_traces(client, ontology, entities)
 
             data = {
@@ -372,7 +371,7 @@ def regenerate_domain(client: anthropic.Anthropic, domain_id: str) -> dict | Non
             if errors:
                 print(f"  Validation errors: {errors[:3]}")
                 if attempt < MAX_RETRIES - 1:
-                    print(f"  Retrying...")
+                    print("  Retrying...")
                     continue
                 else:
                     print(f"  WARNING: Proceeding with {len(errors)} validation errors")
@@ -386,7 +385,7 @@ def regenerate_domain(client: anthropic.Anthropic, domain_id: str) -> dict | Non
             print(f"  Error: {e}")
             traceback.print_exc()
             if attempt < MAX_RETRIES - 1:
-                print(f"  Retrying in 5s...")
+                print("  Retrying in 5s...")
                 time.sleep(5)
             else:
                 print(f"  FAILED after {MAX_RETRIES} attempts")
@@ -427,7 +426,7 @@ def main():
             success += 1
         else:
             failed.append(domain_id)
-            print(f"  FAILED\n")
+            print("  FAILED\n")
 
     print(f"\nDone: {success}/{len(domains)} succeeded")
     if failed:

--- a/src/create_context_graph/cli.py
+++ b/src/create_context_graph/cli.py
@@ -297,19 +297,19 @@ def main(
     except ValueError:
         display_path = out
     console.print(f"  [bold]cd {display_path}[/bold]")
-    console.print(f"  [bold]make install[/bold]       # Install dependencies")
+    console.print("  [bold]make install[/bold]       # Install dependencies")
     if config.neo4j_type == "docker":
-        console.print(f"  [bold]make docker-up[/bold]    # Start Neo4j")
+        console.print("  [bold]make docker-up[/bold]    # Start Neo4j")
     elif config.neo4j_type == "local":
-        console.print(f"  [bold]make neo4j-start[/bold]  # Start Neo4j (requires Node.js)")
+        console.print("  [bold]make neo4j-start[/bold]  # Start Neo4j (requires Node.js)")
     if ingest:
-        console.print(f"  [bold]make seed[/bold]          # Re-seed sample data (already ingested)")
+        console.print("  [bold]make seed[/bold]          # Re-seed sample data (already ingested)")
     else:
-        console.print(f"  [bold]make seed[/bold]          # Seed sample data")
+        console.print("  [bold]make seed[/bold]          # Seed sample data")
     if config.saas_connectors:
-        console.print(f"  [bold]make import[/bold]         # Re-import from connected services")
-    console.print(f"  [bold]make start[/bold]         # Start backend + frontend")
+        console.print("  [bold]make import[/bold]         # Re-import from connected services")
+    console.print("  [bold]make start[/bold]         # Start backend + frontend")
     console.print()
-    console.print(f"  Backend:  http://localhost:8000")
-    console.print(f"  Frontend: http://localhost:3000")
+    console.print("  Backend:  http://localhost:8000")
+    console.print("  Frontend: http://localhost:3000")
     console.print()

--- a/src/create_context_graph/connectors/github_connector.py
+++ b/src/create_context_graph/connectors/github_connector.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any
 
 from create_context_graph.connectors import (
@@ -128,7 +127,7 @@ class GitHubConnector(BaseConnector):
                 "issue_number": issue.number,
                 "state": issue.state,
                 "created_at": issue.created_at.isoformat() if issue.created_at else "",
-                "labels": ",".join(l.name for l in issue.labels),
+                "labels": ",".join(label.name for label in issue.labels),
             })
             relationships.append({
                 "type": "OPENED",

--- a/src/create_context_graph/connectors/gmail_connector.py
+++ b/src/create_context_graph/connectors/gmail_connector.py
@@ -16,8 +16,6 @@
 
 from __future__ import annotations
 
-import base64
-import json
 from typing import Any
 
 from create_context_graph.connectors import (
@@ -69,7 +67,6 @@ class GmailConnector(BaseConnector):
 
         # Fall back to Python Google API
         try:
-            from google_auth_oauthlib.flow import InstalledAppFlow
             from googleapiclient.discovery import build
         except ImportError:
             raise ImportError(

--- a/src/create_context_graph/connectors/oauth.py
+++ b/src/create_context_graph/connectors/oauth.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-import threading
 import urllib.parse
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer

--- a/src/create_context_graph/custom_domain.py
+++ b/src/create_context_graph/custom_domain.py
@@ -220,7 +220,7 @@ def generate_custom_domain(
     client, resolved_provider = _get_llm_client(api_key, provider)
     if client is None:
         raise ValueError(
-            f"Could not initialize LLM client. Install 'anthropic' or 'openai' package."
+            "Could not initialize LLM client. Install 'anthropic' or 'openai' package."
         )
 
     base_yaml, examples = _load_example_yamls()

--- a/src/create_context_graph/generator.py
+++ b/src/create_context_graph/generator.py
@@ -314,9 +314,9 @@ def _generate_static_observation(action: str, domain_name: str) -> str:
     if "check" in action_lower or "verify" in action_lower or "validate" in action_lower:
         return f"Validation completed successfully. All checked parameters are within acceptable thresholds for {domain_name.lower()} standards."
     if "calculate" in action_lower or "compute" in action_lower or "analyze" in action_lower:
-        return f"Analysis complete. Key metrics computed and compared against historical baselines. Results indicate normal operational parameters."
+        return "Analysis complete. Key metrics computed and compared against historical baselines. Results indicate normal operational parameters."
     if "review" in action_lower:
-        return f"Review of available records completed. Identified 3 key factors relevant to the current decision context."
+        return "Review of available records completed. Identified 3 key factors relevant to the current decision context."
     return f"Action completed. Results consistent with expected {domain_name.lower()} domain patterns and prior observations."
 
 

--- a/src/create_context_graph/renderer.py
+++ b/src/create_context_graph/renderer.py
@@ -21,7 +21,7 @@ import shutil
 from importlib.resources import files
 from pathlib import Path
 
-from jinja2 import Environment, PackageLoader, select_autoescape
+from jinja2 import Environment, PackageLoader
 
 from create_context_graph.config import ProjectConfig
 from create_context_graph.ontology import (

--- a/src/create_context_graph/templates/backend/agents/anthropic_tools/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/anthropic_tools/agent.py.j2
@@ -31,7 +31,9 @@ from app.context_graph_client import (
 
 SYSTEM_PROMPT = """{{ system_prompt }}
 
-IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph."""
+IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph.
+
+CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll search for..." or "Let me look up..." before calling a tool — just call the tool immediately. Only generate text AFTER you have received the tool results and are ready to provide your final answer."""
 
 {% raw %}
 client = anthropic.AsyncAnthropic()

--- a/src/create_context_graph/templates/backend/agents/claude_agent_sdk/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/claude_agent_sdk/agent.py.j2
@@ -17,7 +17,9 @@ from app.context_graph_client import (
 
 SYSTEM_PROMPT = """{{ system_prompt }}
 
-IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph."""
+IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph.
+
+CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll search for..." or "Let me look up..." before calling a tool — just call the tool immediately. Only generate text AFTER you have received the tool results and are ready to provide your final answer."""
 
 client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
 

--- a/src/create_context_graph/templates/backend/agents/crewai/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/crewai/agent.py.j2
@@ -42,7 +42,9 @@ def _run_sync(coro):
 
 SYSTEM_PROMPT = """{{ system_prompt }}
 
-IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph."""
+IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph.
+
+CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll search for..." or "Let me look up..." before calling a tool — just call the tool immediately. Only generate text AFTER you have received the tool results and are ready to provide your final answer."""
 
 # ---------------------------------------------------------------------------
 # Agent tools — domain-specific for {{ domain.name }}

--- a/src/create_context_graph/templates/backend/agents/google_adk/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/google_adk/agent.py.j2
@@ -58,7 +58,9 @@ def _run_sync(coro):
 
 SYSTEM_PROMPT = """{{ system_prompt }}
 
-IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph."""
+IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph.
+
+CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll search for..." or "Let me look up..." before calling a tool — just call the tool immediately. Only generate text AFTER you have received the tool results and are ready to provide your final answer."""
 
 # ---------------------------------------------------------------------------
 # Agent tools — domain-specific for {{ domain.name }}

--- a/src/create_context_graph/templates/backend/agents/langgraph/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/langgraph/agent.py.j2
@@ -18,7 +18,9 @@ from app.context_graph_client import (
 
 SYSTEM_PROMPT = """{{ system_prompt }}
 
-IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph."""
+IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph.
+
+CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll search for..." or "Let me look up..." before calling a tool — just call the tool immediately. Only generate text AFTER you have received the tool results and are ready to provide your final answer."""
 
 # ---------------------------------------------------------------------------
 # Agent tools — domain-specific for {{ domain.name }}

--- a/src/create_context_graph/templates/backend/agents/openai_agents/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/openai_agents/agent.py.j2
@@ -16,7 +16,9 @@ from app.context_graph_client import (
 
 SYSTEM_PROMPT = """{{ system_prompt }}
 
-IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph."""
+IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph.
+
+CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll search for..." or "Let me look up..." before calling a tool — just call the tool immediately. Only generate text AFTER you have received the tool results and are ready to provide your final answer."""
 
 # ---------------------------------------------------------------------------
 # Agent tools — domain-specific for {{ domain.name }}

--- a/src/create_context_graph/templates/backend/agents/pydanticai/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/pydanticai/agent.py.j2
@@ -34,6 +34,8 @@ SYSTEM_PROMPT = """{{ system_prompt }}
 
 IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph. If a user asks a question, identify which tool(s) can help answer it and call them.
 
+CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll search for..." or "Let me look up..." before calling a tool — just call the tool immediately. Only generate text AFTER you have received the tool results and are ready to provide your final answer.
+
 When writing Cypher queries with run_cypher:
 - Never combine ORDER BY with DISTINCT or aggregation in the same RETURN clause — use a WITH clause first
 - Always LIMIT results (default LIMIT 25) to avoid overwhelming responses
@@ -167,19 +169,21 @@ async def handle_message_stream(message: str, session_id: str | None = None) -> 
             )
 
     deps = AgentDeps(session_id=session_id)
-    async with agent.run_stream(
+    # Use agent.run() (not run_stream) so the full agent loop completes —
+    # including all tool calls — before we emit the final text.
+    # run_stream stops at the first text part, so it cuts off before tool
+    # results are incorporated when Claude generates "I'll search..." + a tool
+    # call in the same response.  Tool events (tool_start / tool_end) are still
+    # pushed to the SSE queue by execute_cypher during the run.
+    result = await agent.run(
         message, deps=deps, message_history=message_history
-    ) as result:
-        response_text = ""
-        async for chunk in result.stream_text(delta=True):
-            collector.emit_text_delta(chunk)
-            response_text += chunk
+    )
 
-    if not response_text:
-        response_text = result.output or ""
+    response_text = result.output or ""
     if not response_text.strip():
         response_text = "I searched the knowledge graph but couldn't find relevant results for your query. Could you try rephrasing your question?"
 
+    collector.emit_text_delta(response_text)
     await store_message(session_id, "assistant", response_text)
     collector.emit_done(response_text, session_id)
 

--- a/src/create_context_graph/templates/backend/agents/strands/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/strands/agent.py.j2
@@ -55,7 +55,9 @@ def _run_sync(coro):
 
 SYSTEM_PROMPT = """{{ system_prompt }}
 
-IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph."""
+IMPORTANT: You MUST use the available tools to query the knowledge graph before answering any question about the data. Never guess or make up information — always use tools to look up actual data from the graph.
+
+CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll search for..." or "Let me look up..." before calling a tool — just call the tool immediately. Only generate text AFTER you have received the tool results and are ready to provide your final answer."""
 
 # ---------------------------------------------------------------------------
 # Agent tools — domain-specific for {{ domain.name }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 
 import pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,7 +100,7 @@ class TestScaffoldGeneration:
             "--output-dir", str(out),
         ])
         assert result.exit_code == 1
-        assert "already exists" in result.output
+        assert "not empty" in result.output
 
 
 class TestNeo4jAuraEnv:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,8 +15,6 @@
 """Integration tests for the CLI module."""
 
 import json
-import shutil
-from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -41,7 +39,7 @@ class TestListDomains:
         result = runner.invoke(main, ["--list-domains"])
         assert result.exit_code == 0
         # Count non-empty lines that look like domain entries
-        lines = [l for l in result.output.strip().split("\n") if l.strip() and not l.startswith("Available")]
+        lines = [line for line in result.output.strip().split("\n") if line.strip() and not line.startswith("Available")]
         assert len(lines) >= 22
 
 

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -20,7 +20,6 @@ import pytest
 
 from create_context_graph.connectors import (
     CONNECTOR_REGISTRY,
-    BaseConnector,
     NormalizedData,
     get_connector,
     list_connectors,

--- a/tests/test_neo4j_validator.py
+++ b/tests/test_neo4j_validator.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from create_context_graph.neo4j_validator import validate_connection
 

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -20,9 +20,6 @@ import pytest
 
 from create_context_graph.ontology import (
     DomainOntology,
-    EntityTypeDef,
-    PropertyDef,
-    RelationshipDef,
     _sanitize_enum_name,
     generate_cypher_schema,
     generate_pydantic_models,

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -15,7 +15,6 @@
 """Unit tests for the renderer module."""
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ toml = [
 
 [[package]]
 name = "create-context-graph"
-version = "0.5.0"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
  PydanticAI's run_stream fires a FinalResultEvent the moment any TextPart
  begins streaming. When Claude emits "I'll search for..." alongside a tool
  call in the same response, run_stream treats that text as the final output
  and exits — tool results are never incorporated into a real answer.

  Replace agent.run_stream() + stream_text() in the pydanticai template's
  handle_message_stream with agent.run(), which completes the full agent
  loop (all tool calls + final model response) before emitting text. Tool
  events (tool_start/tool_end) still stream in real time via execute_cypher.

  Add a CRITICAL instruction to all eight agent framework templates telling
  the model to call tools directly without introductory text, so it doesn't
  generate "I'll search for..." preamble in its final response either.