### PR TITLE
fix: add python 3.14 limit to requires-python j2 template

### DIFF
--- a/src/create_context_graph/templates/backend/shared/pyproject.toml.j2
+++ b/src/create_context_graph/templates/backend/shared/pyproject.toml.j2
@@ -3,9 +3,9 @@ name = "{{ project_slug }}-backend"
 version = "0.1.0"
 description = "{{ domain.name }} Context Graph Backend"
 {% if framework == 'crewai' -%}
-requires-python = ">=3.11"
+requires-python = ">=3.11, <3.14"
 {% else -%}
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.14"
 {% endif -%}
 dependencies = [
     "fastapi>=0.115",

--- a/tests/test_generated_project.py
+++ b/tests/test_generated_project.py
@@ -921,13 +921,13 @@ class TestDeferredBugFixes:
         renderer = ProjectRenderer(config, ontology)
         renderer.render(out)
         pyproject = (out / "backend" / "pyproject.toml").read_text()
-        assert '>=3.11' in pyproject
+        assert '>=3.11, <3.14' in pyproject
 
     def test_non_crewai_requires_python_310(self, generated_project):
         """BUG-016: Non-CrewAI projects must require Python 3.10+."""
         out, _ = generated_project
         pyproject = (out / "backend" / "pyproject.toml").read_text()
-        assert '>=3.10' in pyproject
+        assert '>=3.10, <3.14' in pyproject
 
     def test_strands_no_nest_asyncio_dep(self, tmp_path):
         """Phase 0: Strands must not depend on nest-asyncio."""


### PR DESCRIPTION
## SUMMARY

Add upper boundary of 3.14 to `requires-python` in `backend/pyproject.toml.j2` so that users running python 3.14 or higher can avoid the `spacy==3.8.14` error.

```
error: Distribution `spacy==3.8.14 @ registry+https://pypi.org/simple` can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're using CPython 3.14 (`cp314`), but `spacy` (v3.8.14) only has wheels with the following Python ABI tags: `cp310`, `cp311`, `cp312`, `cp313`
```

## TEST PLAN

Create a new deployment with create-context-graph and `make install` worked without error; It used a version of python less than 3.14 (Using CPython 3.13.12).