### PR TITLE
Fix Claude Code connector import pipeline and align tutorial with scaffolded output

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -26,7 +26,7 @@ The **POLE+O** entity model is the foundation for all context graphs: **P**erson
 - **Interactive graph visualization** -- NVL-powered graph explorer with entity detail panel, document browser with template filtering, and decision trace viewer.
 - **Rich demo data** -- LLM-generated fixture data per domain: 80-90 entities, 25+ professional documents, and 3-5 multi-step decision traces. Loaded via `make seed`.
 - **Flexible Neo4j setup** -- Neo4j Aura (free cloud), `@johnymontana/neo4j-local`, Docker Compose, or any existing instance.
-- **12 SaaS data connectors** -- GitHub, Slack, Jira, Notion, Gmail, Google Calendar, Salesforce, Linear, Google Workspace, Claude Code, Claude AI, and ChatGPT.
+- **12 SaaS data connectors** -- GitHub (`github`), Slack (`slack`), Jira (`jira`), Notion (`notion`), Gmail (`gmail`), Google Calendar (`gcal`), Salesforce (`salesforce`), Linear (`linear`), Google Workspace (`google-workspace`), Claude Code (`claude-code`), Claude AI (`claude-ai`), and ChatGPT (`chatgpt`). Use the ID in parentheses with `--connector`.
 - **Custom domains** -- Describe your domain in natural language to generate a complete ontology, or write your own YAML definition.
 - **MCP server for Claude Desktop** -- Optionally generate an MCP server config so Claude Desktop queries the same knowledge graph as your web app.
 

--- a/docs/docs/reference/domain-catalog.md
+++ b/docs/docs/reference/domain-catalog.md
@@ -9,30 +9,30 @@ create-context-graph ships with **22 built-in domains**. Each domain includes a 
 
 ## All Domains
 
-| Domain | Name | Entity Types | Agent Tools |
-|--------|------|-------------|-------------|
-| `agent-memory` | 🧠 Agent Memory | 11 | 7 |
-| `conservation` | 🌿 Conservation | 11 | 8 |
-| `data-journalism` | 📰 Data Journalism | 11 | 8 |
-| `digital-twin` | 🏭 Digital Twin | 11 | 8 |
-| `financial-services` | 💰 Financial Services | 10 | 7 |
-| `gaming` | 🎮 Gaming | 11 | 9 |
-| `genai-llm-ops` | 🤖 GenAI & LLM Ops | 11 | 8 |
-| `gis-cartography` | 🗺 GIS & Cartography | 11 | 8 |
-| `golf-sports` | ⛳ Golf Sports | 11 | 8 |
-| `healthcare` | 🏥 Healthcare | 12 | 6 |
-| `hospitality` | 🏨 Hospitality | 11 | 8 |
-| `manufacturing` | 🏭 Manufacturing | 11 | 7 |
-| `oil-gas` | 🛢️ Oil & Gas | 10 | 6 |
-| `personal-knowledge` | 📝 Personal Knowledge | 10 | 8 |
-| `product-management` | 📋 Product Management | 12 | 7 |
-| `real-estate` | 🏠 Real Estate | 10 | 8 |
-| `retail-ecommerce` | 🛒 Retail & E-Commerce | 11 | 6 |
-| `scientific-research` | 🔬 Scientific Research | 11 | 6 |
-| `software-engineering` | 💻 Software Engineering | 11 | 7 |
-| `trip-planning` | 🌍 Trip Planning | 10 | 7 |
-| `vacation-industry` | 🏖 Vacation Industry | 10 | 6 |
-| `wildlife-management` | 🐻 Wildlife Management | 11 | 6 |
+| Domain | Name | Focus | Entity Types | Agent Tools |
+|--------|------|-------|-------------|-------------|
+| `agent-memory` | 🧠 Agent Memory | AI agent conversation and memory management | 11 | 7 |
+| `conservation` | 🌿 Conservation | Environmental conservation programs and endangered species | 11 | 8 |
+| `data-journalism` | 📰 Data Journalism | Investigative reporting, sources, and story threads | 11 | 8 |
+| `digital-twin` | 🏭 Digital Twin | IoT sensor networks and industrial simulation | 11 | 8 |
+| `financial-services` | 💰 Financial Services | Banking, accounts, transactions, and compliance | 10 | 7 |
+| `gaming` | 🎮 Gaming | Game worlds, players, quests, and item economies | 11 | 9 |
+| `genai-llm-ops` | 🤖 GenAI & LLM Ops | LLM deployment, prompts, evaluations, and model versioning | 11 | 8 |
+| `gis-cartography` | 🗺 GIS & Cartography | Geospatial features, map layers, and spatial analysis | 11 | 8 |
+| `golf-sports` | ⛳ Golf Sports | Golf courses, tournaments, player stats, and handicaps | 11 | 8 |
+| `healthcare` | 🏥 Healthcare | Patients, providers, diagnoses, and treatment plans | 12 | 6 |
+| `hospitality` | 🏨 Hospitality | Hotel operations, guest management, and room inventory | 11 | 8 |
+| `manufacturing` | 🏭 Manufacturing | Production lines, quality control, and supply chain | 11 | 7 |
+| `oil-gas` | 🛢️ Oil & Gas | Wells, pipelines, production sites, and inspections | 10 | 6 |
+| `personal-knowledge` | 📝 Personal Knowledge | Personal notes, contacts, projects, and learning | 10 | 8 |
+| `product-management` | 📋 Product Management | Features, roadmaps, user feedback, and sprint planning | 12 | 7 |
+| `real-estate` | 🏠 Real Estate | Properties, listings, agents, and transactions | 10 | 8 |
+| `retail-ecommerce` | 🛒 Retail & E-Commerce | Products, orders, customers, and inventory | 11 | 6 |
+| `scientific-research` | 🔬 Scientific Research | Papers, experiments, datasets, and citations | 11 | 6 |
+| `software-engineering` | 💻 Software Engineering | Repositories, PRs, incidents, deployments, and services | 11 | 7 |
+| `trip-planning` | 🌍 Trip Planning | Itinerary assembly, destinations, and travel logistics | 10 | 7 |
+| `vacation-industry` | 🏖 Vacation Industry | Tour operators, packages, OTA supply chain, and bookings | 10 | 6 |
+| `wildlife-management` | 🐻 Wildlife Management | Animal tracking, habitats, populations, and rangers | 11 | 6 |
 
 ## Domain Details
 

--- a/docs/docs/tutorials/claude-code-sessions.md
+++ b/docs/docs/tutorials/claude-code-sessions.md
@@ -57,7 +57,7 @@ Before you begin, make sure you have:
   - neo4j-local: `npx @johnymontana/neo4j-local`
 - **uv** (recommended) -- install with `curl -LsSf https://astral.sh/uv/install.sh | sh`
 - **Claude Code session history** -- at least one session in `~/.claude/projects/`
-- **An LLM API key** -- `ANTHROPIC_API_KEY` (for most frameworks) or `OPENAI_API_KEY` / `GOOGLE_API_KEY` depending on your framework choice
+- **An LLM API key** (required for the chat agent) -- `ANTHROPIC_API_KEY` (for most frameworks) or `OPENAI_API_KEY` / `GOOGLE_API_KEY` depending on your framework choice
 
 :::caution Python version errors
 If you see `requires-python >= 3.11` errors during installation, your active Python is too old. Common fixes:
@@ -158,21 +158,19 @@ Navigate to your project:
 cd my-dev-graph
 ```
 
-**Configure your environment** by copying the example file and editing it:
+**Configure your environment.** The scaffolded project generates a `.env` file with working Neo4j defaults. Edit it with your credentials:
 
 ```bash
-cp .env.example .env
-```
-
-Edit `.env` with your Neo4j connection details and API key:
-
-```bash
-# .env
+# .env (already generated — edit in place, don't overwrite)
 NEO4J_URI=neo4j://localhost:7687
 NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=password
-ANTHROPIC_API_KEY=sk-ant-...
+NEO4J_PASSWORD=password          # change to match your Neo4j instance
+ANTHROPIC_API_KEY=sk-ant-...     # required for the chat agent in Step 4
 ```
+
+:::warning API key required for chat
+The chat agent in Step 4 requires an `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GOOGLE_API_KEY` depending on your framework). Without it, the graph visualization, document browser, and decision trace viewer will work, but the chat panel will return an error.
+:::
 
 :::tip Using Neo4j Aura?
 If you're using Neo4j Aura, set `NEO4J_URI=neo4j+s://xxxxxxxx.databases.neo4j.io` with the connection URI from your Aura console.
@@ -207,6 +205,16 @@ Loading fixture data...
   Created 4 decision traces
 Done. Knowledge graph ready.
 ```
+
+:::tip Verify the seed
+To confirm your data loaded correctly, you can query the Neo4j instance directly:
+
+```bash
+make test-connection
+```
+
+This should print "Neo4j connection successful". The exact entity counts depend on the number and size of your Claude Code sessions.
+:::
 
 ## Step 3: Start the Application (~1 min)
 
@@ -519,15 +527,29 @@ make import-and-seed
 
 The import uses MERGE operations, so re-importing is safe -- existing nodes are updated rather than duplicated.
 
-Use `--claude-code-since` to limit imports to recent sessions:
+:::tip Customizing re-imports via `.env`
+To change the import scope after scaffolding, edit the Claude Code settings in your `.env` file:
 
 ```bash
-uvx create-context-graph my-dev-graph \
-  --domain software-engineering \
-  --framework claude-agent-sdk \
-  --connector claude-code \
-  --claude-code-since 2026-04-01
+# Import all projects (not just current directory)
+CLAUDE_CODE_SCOPE=all
+
+# Limit to recent sessions
+CLAUDE_CODE_SINCE=2026-04-01
+
+# Import at most 50 sessions
+CLAUDE_CODE_MAX_SESSIONS=50
+
+# Store full message content (default: truncated to 2000 chars)
+CLAUDE_CODE_CONTENT_MODE=full
 ```
+
+These settings only affect `make import` / `make import-and-seed`. The initial scaffold import uses the CLI flags instead.
+:::
+
+:::note Session deduplication
+Because seed uses `MERGE` by name, re-seeding updates existing nodes rather than creating duplicates. However, sessions that were deleted from `~/.claude/projects/` will remain as stale nodes in Neo4j. To start fresh, run `make reset` before `make import-and-seed`.
+:::
 
 ## Troubleshooting
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -14,7 +14,18 @@ const config: Config = {
   markdown: {
     mermaid: true,
   },
-  themes: ['@docusaurus/theme-mermaid', '@easyops-cn/docusaurus-search-local'],
+  themes: [
+    '@docusaurus/theme-mermaid',
+    [
+      '@easyops-cn/docusaurus-search-local',
+      {
+        hashed: true,
+        indexDocs: true,
+        indexBlog: false,
+        docsRouteBasePath: '/docs',
+      },
+    ],
+  ],
 
   url: 'https://create-context-graph.dev',
   baseUrl: '/',

--- a/docs/src/components/animations/ContextGraphExplainer.tsx
+++ b/docs/src/components/animations/ContextGraphExplainer.tsx
@@ -131,12 +131,12 @@ export function ContextGraphExplainer() {
     [0, 1, 1]
   );
 
-  // Text label opacities
+  // Text label opacities — tightened transitions to avoid overlap
   const textOpacities = [
-    useTransform(scrollYProgress, [0, 0.08, 0.22, 0.28], [0, 1, 1, 0]),
-    useTransform(scrollYProgress, [0.22, 0.3, 0.47, 0.53], [0, 1, 1, 0]),
-    useTransform(scrollYProgress, [0.47, 0.55, 0.72, 0.78], [0, 1, 1, 0]),
-    useTransform(scrollYProgress, [0.72, 0.82, 1, 1], [0, 1, 1, 1]),
+    useTransform(scrollYProgress, [0, 0.08, 0.2, 0.24], [0, 1, 1, 0]),
+    useTransform(scrollYProgress, [0.26, 0.32, 0.45, 0.49], [0, 1, 1, 0]),
+    useTransform(scrollYProgress, [0.51, 0.57, 0.7, 0.74], [0, 1, 1, 0]),
+    useTransform(scrollYProgress, [0.76, 0.82, 1, 1], [0, 1, 1, 1]),
   ];
 
   // Reduced motion: show everything statically

--- a/docs/src/components/animations/DomainCarousel.module.css
+++ b/docs/src/components/animations/DomainCarousel.module.css
@@ -57,6 +57,20 @@
   padding: 0 2rem;
 }
 
+.catalogLink {
+  display: block;
+  text-align: center;
+  margin-top: 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.catalogLink:hover {
+  text-decoration: underline;
+}
+
 .cardWrapper {
   flex-shrink: 0;
   width: 280px;

--- a/docs/src/components/animations/DomainCarousel.tsx
+++ b/docs/src/components/animations/DomainCarousel.tsx
@@ -86,6 +86,9 @@ export function DomainCarousel() {
         <div className={styles.trackFade} />
       </div>
       <div className={styles.dragHint}>Drag to explore &middot; Hover to flip</div>
+      <a href="/docs/reference/domain-catalog" className={styles.catalogLink}>
+        See all 22 domains &rarr;
+      </a>
     </section>
   );
 }

--- a/docs/src/components/animations/HowItWorks.module.css
+++ b/docs/src/components/animations/HowItWorks.module.css
@@ -74,9 +74,9 @@
   font-family: 'Syne', sans-serif;
   font-size: 1.1rem;
   font-weight: 700;
-  border: 2px solid rgba(255, 255, 255, 0.1);
+  border: 2px solid rgba(99, 102, 241, 0.25);
   background: var(--ifm-background-color, #1a1a2e);
-  color: var(--color-terminal-gray, #9CA3AF);
+  color: var(--ifm-color-emphasis-700, #6B7280);
   transition: border-color 0.4s, color 0.4s, background 0.4s;
 }
 
@@ -88,8 +88,8 @@
 
 [data-theme="light"] .stepNumber {
   background: var(--ifm-background-color, #ffffff);
-  border-color: rgba(0, 0, 0, 0.1);
-  color: rgba(0, 0, 0, 0.3);
+  border-color: rgba(99, 102, 241, 0.2);
+  color: rgba(0, 0, 0, 0.5);
 }
 
 [data-theme="light"] .stepNumberActive {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -129,3 +129,18 @@ html {
   background: rgba(255, 255, 255, 0.85);
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
 }
+
+/* Dark mode announcement bar */
+[data-theme="dark"] div[class*="announcementBar"] {
+  background: #1a1a2e;
+  color: rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+[data-theme="dark"] div[class*="announcementBar"] button {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+[data-theme="dark"] div[class*="announcementBar"] button:hover {
+  color: rgba(255, 255, 255, 0.9);
+}

--- a/docs/src/pages/404.tsx
+++ b/docs/src/pages/404.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+
+export default function NotFound(): React.JSX.Element {
+  return (
+    <Layout title="Page Not Found">
+      <main
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '50vh',
+          padding: '2rem',
+          textAlign: 'center',
+        }}
+      >
+        <h1 style={{ fontSize: '2.5rem', marginBottom: '1rem' }}>
+          Page Not Found
+        </h1>
+        <p style={{ fontSize: '1.2rem', color: 'var(--ifm-color-emphasis-600)', maxWidth: '500px' }}>
+          The page you're looking for doesn't exist or has been moved.
+        </p>
+        <div style={{ display: 'flex', gap: '1rem', marginTop: '2rem', flexWrap: 'wrap', justifyContent: 'center' }}>
+          <a
+            href="/docs/intro"
+            style={{
+              padding: '0.75rem 1.5rem',
+              borderRadius: '8px',
+              background: 'var(--ifm-color-primary)',
+              color: 'white',
+              textDecoration: 'none',
+              fontWeight: 600,
+            }}
+          >
+            Introduction
+          </a>
+          <a
+            href="/docs/quick-start"
+            style={{
+              padding: '0.75rem 1.5rem',
+              borderRadius: '8px',
+              border: '1px solid var(--ifm-color-primary)',
+              color: 'var(--ifm-color-primary)',
+              textDecoration: 'none',
+              fontWeight: 600,
+            }}
+          >
+            Quick Start
+          </a>
+          <a
+            href="https://github.com/neo4j-labs/create-context-graph/issues/new?title=Broken+link&body=I+found+a+broken+link+on+the+docs+site."
+            style={{
+              padding: '0.75rem 1.5rem',
+              borderRadius: '8px',
+              border: '1px solid var(--ifm-color-emphasis-300)',
+              color: 'var(--ifm-color-emphasis-700)',
+              textDecoration: 'none',
+              fontWeight: 600,
+            }}
+          >
+            Report Broken Link
+          </a>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/src/create_context_graph/renderer.py
+++ b/src/create_context_graph/renderer.py
@@ -180,6 +180,37 @@ _CLAUDE_CODE_AGENT_TOOLS: list[dict] = [
     },
 ]
 
+# ---------------------------------------------------------------------------
+# Claude Code session connector demo scenarios
+# ---------------------------------------------------------------------------
+
+_CLAUDE_CODE_SCENARIOS: list[dict] = [
+    {
+        "name": "Session Intelligence",
+        "prompts": [
+            "What files have I modified most frequently?",
+            "Show me the decisions made in my recent sessions",
+            "What errors have I encountered and how were they resolved?",
+        ],
+    },
+    {
+        "name": "Development Patterns",
+        "prompts": [
+            "What are my coding preferences?",
+            "Which tools do I use most frequently?",
+            "Give me an overview of my project activity",
+        ],
+    },
+    {
+        "name": "Code Archaeology",
+        "prompts": [
+            "What was I working on in my last session?",
+            "Show me the reasoning trace for my most recent session",
+            "Which files were involved in fixing the last error?",
+        ],
+    },
+]
+
 
 # ---------------------------------------------------------------------------
 # Renderer
@@ -222,7 +253,7 @@ class ProjectRenderer:
             "base_entity_types": base_entity_types,
             "domain_entity_types": domain_entity_types,
             "relationships": [r.model_dump() for r in self.ontology.relationships],
-            "demo_scenarios": [s.model_dump() for s in self.ontology.demo_scenarios],
+            "demo_scenarios": self._build_demo_scenarios(),
             "agent_tools": self._build_agent_tools(),
             "framework": self.config.resolved_framework,
             "framework_display_name": self.config.framework_display_name,
@@ -271,6 +302,12 @@ class ProjectRenderer:
                 "file modification history."
             )
         return prompt
+
+    def _build_demo_scenarios(self) -> list[dict]:
+        """Build demo scenarios, replacing with connector-specific ones if active."""
+        if "claude-code" in self.config.saas_connectors:
+            return _CLAUDE_CODE_SCENARIOS
+        return [s.model_dump() for s in self.ontology.demo_scenarios]
 
     def _build_agent_tools(self) -> list[dict]:
         """Build agent tools list, including connector-specific tools."""

--- a/src/create_context_graph/templates/backend/connectors/claude_code_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/claude_code_connector.py.j2
@@ -17,9 +17,111 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Tool categories for file tracking.
 _WRITE_TOOLS = {"Write", "Edit", "NotebookEdit"}
 _READ_TOOLS = {"Read", "Grep", "Glob"}
+_FILE_TOOLS = _WRITE_TOOLS | _READ_TOOLS
+
+_EXT_TO_LANG: dict[str, str] = {
+    "py": "python", "js": "javascript", "ts": "typescript", "tsx": "typescript",
+    "jsx": "javascript", "rs": "rust", "go": "go", "java": "java", "rb": "ruby",
+    "cpp": "cpp", "c": "c", "h": "c", "hpp": "cpp", "cs": "csharp", "kt": "kotlin",
+    "swift": "swift", "sh": "shell", "bash": "shell", "zsh": "shell",
+    "yml": "yaml", "yaml": "yaml", "json": "json", "toml": "toml", "xml": "xml",
+    "html": "html", "css": "css", "scss": "scss", "sql": "sql", "md": "markdown",
+    "graphql": "graphql", "proto": "protobuf", "dockerfile": "dockerfile",
+}
+
+_RERUN_RE = re.compile(r"\s*\[rerun:\s*b\d+\]\s*$")
+
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"), "[REDACTED]"),
+    (re.compile(r"sk-proj-[A-Za-z0-9_-]{20,}"), "[REDACTED]"),
+    (re.compile(r"sk-[A-Za-z0-9]{20,}"), "[REDACTED]"),
+    (re.compile(r"gh[ps]_[A-Za-z0-9]{36,}"), "[REDACTED]"),
+    (re.compile(r"gho_[A-Za-z0-9]{36,}"), "[REDACTED]"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{22,}"), "[REDACTED]"),
+    (re.compile(r"xox[bpras]-[A-Za-z0-9-]{10,}"), "[REDACTED]"),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED]"),
+    (re.compile(r"Bearer\s+[A-Za-z0-9._-]{20,}"), "Bearer [REDACTED]"),
+    (re.compile(
+        r"(?i)(api[_-]?key|api[_-]?secret|secret[_-]?key|access[_-]?token|auth[_-]?token)"
+        r"""[\s]*[=:]\s*["']?[A-Za-z0-9._/+-]{16,}["']?"""
+    ), r"\1=[REDACTED]"),
+    (re.compile(
+        r"(?i)(password|passwd|pwd)"
+        r"""[\s]*[=:]\s*["']?[^\s"']{4,}["']?"""
+    ), r"\1=[REDACTED]"),
+    (re.compile(
+        r"(?i)(mysql|postgres|postgresql|mongodb|redis|amqp|neo4j)://"
+        r"[^:]+:[^@]+@"
+    ), r"\1://[REDACTED]@"),
+]
+
+_CORRECTION_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\bno[,.]?\s+(instead|don'?t|do not|use|try|change|switch)", re.I),
+    re.compile(r"\bactually[,.]?\s+(let'?s|use|try|change|I want|we should)", re.I),
+    re.compile(r"\bthat'?s not (what|right|correct)", re.I),
+    re.compile(r"\brevert\b", re.I),
+    re.compile(r"\bundo\b", re.I),
+    re.compile(r"\bchange it to\b", re.I),
+    re.compile(r"\bdon'?t do that\b", re.I),
+    re.compile(r"\bnot that\b", re.I),
+]
+
+_PREFERENCE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\balways\s+use\s+(.{3,60})", re.I), "coding_style"),
+    (re.compile(r"\bnever\s+use\s+(.{3,60})", re.I), "coding_style"),
+    (re.compile(r"\bprefer\s+(.{3,60})\s+over\s+(.{3,60})", re.I), "framework_choice"),
+    (re.compile(r"\bdon'?t\s+use\s+(.{3,60})", re.I), "coding_style"),
+    (re.compile(r"\buse\s+(.{3,40})\s+instead\s+of\s+(.{3,40})", re.I), "framework_choice"),
+    (re.compile(r"\bmake\s+sure\s+to\s+(.{3,60})", re.I), "coding_style"),
+    (re.compile(r"\bI\s+prefer\s+(.{3,60})", re.I), "coding_style"),
+    (re.compile(r"\bwe\s+should\s+always\s+(.{3,60})", re.I), "coding_style"),
+    (re.compile(r"\bI\s+like\s+(?:to\s+)?(.{3,60})", re.I), "coding_style"),
+    (re.compile(r"\buse\s+(ruff|black|prettier|eslint|flake8|mypy)\b", re.I), "tool_configuration"),
+    (re.compile(r"\buse\s+(pytest|jest|vitest|mocha)\b", re.I), "testing_approach"),
+    (re.compile(r"\buse\s+(snake_case|camelCase|PascalCase)\b", re.I), "naming_convention"),
+]
+
+
+def _redact(text: str) -> str:
+    if not text:
+        return text
+    result = text
+    for pattern, replacement in _SECRET_PATTERNS:
+        result = pattern.sub(replacement, result)
+    return result
+
+
+def _clean(text: str) -> str:
+    return _RERUN_RE.sub("", _redact(text))
+
+
+def _short_hash(text: str) -> str:
+    return hashlib.md5(text.encode()).hexdigest()[:10]
+
+
+def _detect_language(file_path: str) -> str:
+    basename = os.path.basename(file_path).lower()
+    if basename == "dockerfile":
+        return "dockerfile"
+    if basename == "makefile":
+        return "makefile"
+    ext = os.path.splitext(file_path)[1].lstrip(".").lower()
+    return _EXT_TO_LANG.get(ext, ext or "unknown")
+
+
+def _is_valid_path(path: str) -> bool:
+    if not path or len(path) < 2:
+        return False
+    if path.startswith("/") or path.startswith("~") or "/" in path:
+        try:
+            int(path)
+            return False
+        except ValueError:
+            pass
+        return True
+    return False
 
 
 class ClaudeCodeConnector:
@@ -38,12 +140,12 @@ class ClaudeCodeConnector:
 
     def authenticate(self, credentials: dict[str, str]) -> None:
         """Parse configuration from credentials dict."""
-        base = credentials.get("base_path", "")
+        base = credentials.get("base_path") or ""
         self._base_path = Path(base).expanduser() if base else None
-        self._scope = credentials.get("scope", "current")
-        self._content_mode = credentials.get("content_mode", "truncated")
-        self._since = credentials.get("since", "")
-        self._max_sessions = int(credentials.get("max_sessions", "0"))
+        self._scope = credentials.get("scope") or "current"
+        self._content_mode = credentials.get("content_mode") or "truncated"
+        self._since = credentials.get("since") or ""
+        self._max_sessions = int(credentials.get("max_sessions") or 0)
 
     def fetch(self, **kwargs: Any) -> dict[str, Any]:
         """Parse sessions and return entities, relationships, documents."""
@@ -56,6 +158,8 @@ class ClaudeCodeConnector:
         relationships: list[dict] = []
         documents: list[dict] = []
         seen_files: dict[str, dict] = {}
+        seen_branches: dict[str, dict] = {}
+        all_parsed_sessions: list[dict] = []
 
         for project_dir in sorted(base.iterdir()):
             if not project_dir.is_dir():
@@ -71,21 +175,26 @@ class ClaudeCodeConnector:
                 "sessionCount": len(sessions),
             })
 
+            session_count = 0
             for jsonl_path in sorted(sessions, key=lambda p: p.stat().st_mtime, reverse=True):
+                if self._max_sessions and session_count >= self._max_sessions:
+                    break
+                session_count += 1
+
                 session_id = jsonl_path.stem
                 messages, tool_calls, meta = self._parse_session(jsonl_path)
 
-                # Use session_id as the unique merge key to avoid collisions
-                # when multiple sessions share the same opening prompt.
                 session_name = f"Session:{session_id}"
                 first_prompt = meta.get("first_prompt", "")
+                git_branch = meta.get("git_branch", "")
+
                 entities.setdefault("Session", []).append({
                     "name": session_name,
                     "sessionId": session_id,
-                    "firstPrompt": first_prompt[:200] if first_prompt else "",
+                    "firstPrompt": _clean(first_prompt[:200]) if first_prompt else "",
                     "startedAt": meta.get("first_timestamp", ""),
                     "endedAt": meta.get("last_timestamp", ""),
-                    "branch": meta.get("git_branch", ""),
+                    "branch": git_branch,
                     "messageCount": len(messages),
                 })
 
@@ -97,13 +206,29 @@ class ClaudeCodeConnector:
                     "target_label": "Session",
                 })
 
-                # Build message and tool call entities
+                # GitBranch entity
+                if git_branch and git_branch not in seen_branches:
+                    seen_branches[git_branch] = {
+                        "name": git_branch,
+                        "project": decoded_path,
+                    }
+                if git_branch:
+                    relationships.append({
+                        "type": "ON_BRANCH",
+                        "source_name": session_name,
+                        "source_label": "Session",
+                        "target_name": git_branch,
+                        "target_label": "GitBranch",
+                    })
+
+                # Message entities with NEXT sequencing
+                prev_msg_name = None
                 for msg in messages:
                     msg_name = f"msg-{msg['uuid'][:12]}"
                     entities.setdefault("Message", []).append({
                         "name": msg_name,
                         "role": msg["role"],
-                        "content": msg["content"],
+                        "content": _clean(msg["content"]),
                         "timestamp": msg["timestamp"],
                     })
                     relationships.append({
@@ -113,45 +238,117 @@ class ClaudeCodeConnector:
                         "target_name": msg_name,
                         "target_label": "Message",
                     })
+                    if prev_msg_name:
+                        relationships.append({
+                            "type": "NEXT",
+                            "source_name": prev_msg_name,
+                            "source_label": "Message",
+                            "target_name": msg_name,
+                            "target_label": "Message",
+                        })
+                    prev_msg_name = msg_name
 
+                # ToolCall entities with PRECEDED_BY sequencing
+                prev_tc_name = None
                 for tc in tool_calls:
                     summary = self._summarize_input(tc["tool_name"], tc.get("input", {}))
                     tc_name = f"{tc['tool_name']}: {summary[:60]}" if summary else tc["tool_name"]
+                    is_error = tc.get("is_error", False)
+
                     entities.setdefault("ToolCall", []).append({
                         "name": tc_name,
                         "toolName": tc["tool_name"],
-                        "input": summary,
-                        "isError": tc.get("is_error", False),
+                        "input": _clean(summary),
+                        "isError": is_error,
                         "timestamp": tc["timestamp"],
                     })
 
-                    # File relationships
-                    file_path = tc.get("input", {}).get("file_path", "")
-                    if file_path:
-                        if file_path not in seen_files:
-                            ext = os.path.splitext(file_path)[1].lstrip(".")
-                            seen_files[file_path] = {
-                                "name": file_path,
-                                "path": file_path,
-                                "language": ext,
-                            }
-                        rel_type = "MODIFIED_FILE" if tc["tool_name"] in _WRITE_TOOLS else "READ_FILE"
+                    # USED_TOOL from parent message
+                    if tc.get("parent_msg_name"):
                         relationships.append({
-                            "type": rel_type,
+                            "type": "USED_TOOL",
+                            "source_name": tc["parent_msg_name"],
+                            "source_label": "Message",
+                            "target_name": tc_name,
+                            "target_label": "ToolCall",
+                        })
+
+                    if prev_tc_name:
+                        relationships.append({
+                            "type": "PRECEDED_BY",
                             "source_name": tc_name,
                             "source_label": "ToolCall",
-                            "target_name": file_path,
-                            "target_label": "File",
+                            "target_name": prev_tc_name,
+                            "target_label": "ToolCall",
+                        })
+                    prev_tc_name = tc_name
+
+                    # File relationships — only from file-bearing tools
+                    if tc["tool_name"] in _FILE_TOOLS:
+                        file_path = tc.get("input", {}).get("file_path", "")
+                        if file_path and _is_valid_path(file_path):
+                            if file_path not in seen_files:
+                                seen_files[file_path] = {
+                                    "name": file_path,
+                                    "path": file_path,
+                                    "language": _detect_language(file_path),
+                                    "modificationCount": 0,
+                                    "readCount": 0,
+                                }
+                            if tc["tool_name"] in _WRITE_TOOLS:
+                                seen_files[file_path]["modificationCount"] += 1
+                                rel_type = "MODIFIED_FILE"
+                            else:
+                                seen_files[file_path]["readCount"] += 1
+                                rel_type = "READ_FILE"
+                            relationships.append({
+                                "type": rel_type,
+                                "source_name": tc_name,
+                                "source_label": "ToolCall",
+                                "target_name": file_path,
+                                "target_label": "File",
+                            })
+
+                    # Error entity
+                    if is_error:
+                        error_text = tc.get("error_content", summary)
+                        error_name = f"error-{_short_hash(f'{session_id}-{tc.get("tool_use_id", "")}')}"
+                        entities.setdefault("Error", []).append({
+                            "name": error_name,
+                            "message": _clean(error_text[:300]),
+                            "toolName": tc["tool_name"],
+                            "timestamp": tc["timestamp"],
+                        })
+                        relationships.append({
+                            "type": "ENCOUNTERED_ERROR",
+                            "source_name": tc_name,
+                            "source_label": "ToolCall",
+                            "target_name": error_name,
+                            "target_label": "Error",
                         })
 
                 # Session document for full-text search
                 doc_parts = [f"[{m['role']}] {m['content'][:300]}" for m in messages if m["content"]]
                 documents.append({
                     "title": f"Claude Code Session: {session_name}",
-                    "content": "\n\n".join(doc_parts)[:10000],
+                    "content": _clean("\n\n".join(doc_parts)[:10000]),
+                })
+
+                all_parsed_sessions.append({
+                    "session_id": session_id,
+                    "session_name": session_name,
+                    "messages": messages,
+                    "tool_calls": tool_calls,
                 })
 
         entities["File"] = list(seen_files.values())
+        entities["GitBranch"] = list(seen_branches.values())
+
+        # Decision extraction
+        self._extract_decisions(all_parsed_sessions, entities, relationships)
+
+        # Preference extraction
+        self._extract_preferences(all_parsed_sessions, entities, relationships)
 
         return {
             "entities": entities,
@@ -159,12 +356,189 @@ class ClaudeCodeConnector:
             "documents": documents,
         }
 
+    def _extract_decisions(
+        self,
+        parsed_sessions: list[dict],
+        entities: dict[str, list[dict]],
+        relationships: list[dict],
+    ) -> None:
+        """Extract decisions from user corrections and error-resolution cycles."""
+        for session in parsed_sessions:
+            session_id = session["session_id"]
+            session_name = session["session_name"]
+            messages = session["messages"]
+            tool_calls = session["tool_calls"]
+
+            # User corrections
+            for i, msg in enumerate(messages):
+                if msg["role"] != "user" or i == 0:
+                    continue
+                text = msg.get("content", "")
+                if not text or len(text) < 5:
+                    continue
+
+                if not any(p.search(text) for p in _CORRECTION_PATTERNS):
+                    continue
+
+                prev_assistant = None
+                for j in range(i - 1, -1, -1):
+                    if messages[j]["role"] == "assistant":
+                        prev_assistant = messages[j]
+                        break
+                if not prev_assistant:
+                    continue
+
+                decision_id = _short_hash(f"{session_id}-correction-{i}")
+                decision_name = f"decision-{decision_id}"
+                entities.setdefault("Decision", []).append({
+                    "name": decision_name,
+                    "description": _clean(f"User correction: {text[:120]}"),
+                    "timestamp": msg["timestamp"],
+                    "outcome": "REVISED",
+                    "confidence": 0.75,
+                    "category": "correction",
+                    "sessionId": session_id,
+                })
+
+                orig_text = prev_assistant.get("content", "")[:200]
+                orig_alt_name = f"alt-{decision_id}-original"
+                entities.setdefault("Alternative", []).append({
+                    "name": orig_alt_name,
+                    "description": _clean(orig_text) if orig_text else "Original approach",
+                    "wasChosen": False,
+                })
+
+                corr_alt_name = f"alt-{decision_id}-correction"
+                entities.setdefault("Alternative", []).append({
+                    "name": corr_alt_name,
+                    "description": _clean(text[:200]),
+                    "wasChosen": True,
+                })
+
+                relationships.extend([
+                    {"type": "MADE_DECISION", "source_name": session_name,
+                     "source_label": "Session", "target_name": decision_name,
+                     "target_label": "Decision"},
+                    {"type": "REJECTED", "source_name": decision_name,
+                     "source_label": "Decision", "target_name": orig_alt_name,
+                     "target_label": "Alternative"},
+                    {"type": "CHOSE", "source_name": decision_name,
+                     "source_label": "Decision", "target_name": corr_alt_name,
+                     "target_label": "Alternative"},
+                ])
+
+            # Error-resolution cycles
+            error_tcs = [tc for tc in tool_calls if tc.get("is_error")]
+            for err_tc in error_tcs:
+                err_idx = tool_calls.index(err_tc)
+                resolution = None
+                for k in range(err_idx + 1, min(err_idx + 5, len(tool_calls))):
+                    if not tool_calls[k].get("is_error"):
+                        resolution = tool_calls[k]
+                        break
+                if not resolution:
+                    continue
+
+                decision_id = _short_hash(
+                    f"{session_id}-errfix-{err_tc.get('tool_use_id', '')}"
+                )
+                decision_name = f"decision-{decision_id}"
+                err_summary = self._summarize_input(
+                    err_tc["tool_name"], err_tc.get("input", {})
+                )
+                res_summary = self._summarize_input(
+                    resolution["tool_name"], resolution.get("input", {})
+                )
+
+                entities.setdefault("Decision", []).append({
+                    "name": decision_name,
+                    "description": _clean(f"Fix error in {err_tc['tool_name']}: {err_summary[:80]}"),
+                    "timestamp": resolution["timestamp"],
+                    "outcome": "RESOLVED",
+                    "confidence": 0.65,
+                    "category": "error_resolution",
+                    "sessionId": session_id,
+                })
+
+                relationships.append({
+                    "type": "MADE_DECISION", "source_name": session_name,
+                    "source_label": "Session", "target_name": decision_name,
+                    "target_label": "Decision",
+                })
+
+    def _extract_preferences(
+        self,
+        parsed_sessions: list[dict],
+        entities: dict[str, list[dict]],
+        relationships: list[dict],
+    ) -> None:
+        """Extract developer preferences from explicit statements."""
+        seen_prefs: dict[str, dict] = {}
+
+        for session in parsed_sessions:
+            session_id = session["session_id"]
+            for msg in session["messages"]:
+                if msg["role"] != "user":
+                    continue
+                text = msg.get("content", "")
+                if not text:
+                    continue
+
+                for pattern, category in _PREFERENCE_PATTERNS:
+                    match = pattern.search(text)
+                    if not match:
+                        continue
+
+                    pref_value = match.group(0).strip()[:100]
+                    pref_key = re.sub(r"\s+", " ", pref_value.lower())
+
+                    if pref_key in seen_prefs:
+                        seen_prefs[pref_key]["session_count"] += 1
+                        seen_prefs[pref_key]["confidence"] = min(
+                            seen_prefs[pref_key]["confidence"] + 0.15, 0.95
+                        )
+                    else:
+                        seen_prefs[pref_key] = {
+                            "name": f"pref-{_short_hash(pref_key)}",
+                            "category": category,
+                            "key": pref_key,
+                            "value": pref_value,
+                            "confidence": 0.6,
+                            "extractedFrom": "explicit_statement",
+                            "firstSeenAt": msg.get("timestamp", ""),
+                            "session_count": 1,
+                            "source_msg": f"msg-{msg['uuid'][:12]}",
+                        }
+
+        for pref in seen_prefs.values():
+            if pref["confidence"] < 0.4:
+                continue
+            entities.setdefault("Preference", []).append({
+                "name": pref["name"],
+                "category": pref["category"],
+                "key": pref["key"],
+                "value": pref["value"],
+                "confidence": round(pref["confidence"], 2),
+                "extractedFrom": pref["extractedFrom"],
+                "firstSeenAt": pref["firstSeenAt"],
+                "sessionCount": pref["session_count"],
+            })
+            if pref.get("source_msg"):
+                relationships.append({
+                    "type": "EXPRESSES_PREFERENCE",
+                    "source_name": pref["source_msg"],
+                    "source_label": "Message",
+                    "target_name": pref["name"],
+                    "target_label": "Preference",
+                })
+
     def _parse_session(self, jsonl_path: Path) -> tuple[list[dict], list[dict], dict]:
         """Parse a JSONL session file into messages, tool calls, and metadata."""
         messages: list[dict] = []
         tool_calls: list[dict] = []
         tool_results: dict[str, dict] = {}
         meta: dict[str, str] = {}
+        current_msg_name: str = ""
 
         try:
             with open(jsonl_path, encoding="utf-8") as f:
@@ -193,25 +567,24 @@ class ClaudeCodeConnector:
                     msg = entry.get("message", {})
                     text = self._extract_text(msg)
 
-                    # Content truncation
                     stored = text
                     if self._content_mode == "none":
                         stored = ""
                     elif self._content_mode == "truncated" and len(text) > self._max_content_len:
                         stored = text[:self._max_content_len] + "..."
 
+                    uuid = entry.get("uuid", "")
+                    current_msg_name = f"msg-{uuid[:12]}" if uuid else ""
                     messages.append({
-                        "uuid": entry.get("uuid", ""),
+                        "uuid": uuid,
                         "role": msg.get("role", ""),
                         "content": stored,
                         "timestamp": timestamp,
                     })
 
-                    # First user prompt
                     if entry_type == "user" and not meta.get("first_prompt") and len(text) > 5:
                         meta["first_prompt"] = text[:200]
 
-                    # Extract tool_use / tool_result blocks
                     content_blocks = msg.get("content", [])
                     if isinstance(content_blocks, list):
                         for block in content_blocks:
@@ -224,19 +597,33 @@ class ClaudeCodeConnector:
                                     "input": block.get("input", {}),
                                     "is_error": False,
                                     "timestamp": timestamp,
+                                    "parent_msg_name": current_msg_name,
+                                    "error_content": "",
                                 })
                             elif block.get("type") == "tool_result":
                                 is_err = block.get("is_error", False)
-                                tool_results[block.get("tool_use_id", "")] = {"is_error": is_err}
+                                content = ""
+                                if isinstance(block.get("content"), str):
+                                    content = block["content"][:300]
+                                elif isinstance(block.get("content"), list):
+                                    for cb in block["content"]:
+                                        if isinstance(cb, dict) and cb.get("type") == "text":
+                                            content = cb.get("text", "")[:300]
+                                            break
+                                tool_results[block.get("tool_use_id", "")] = {
+                                    "is_error": is_err,
+                                    "content": content,
+                                }
 
         except OSError as exc:
             logger.warning("Could not read %s: %s", jsonl_path, exc)
 
-        # Match results to tool calls
         for tc in tool_calls:
             tr = tool_results.get(tc["tool_use_id"])
             if tr:
                 tc["is_error"] = tr.get("is_error", False)
+                if tr.get("is_error"):
+                    tc["error_content"] = tr.get("content", "")
 
         return messages, tool_calls, meta
 

--- a/src/create_context_graph/templates/backend/connectors/import_data.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/import_data.py.j2
@@ -94,22 +94,22 @@ def main():
         }))
 {% endraw %}{% elif conn == 'google-workspace' %}{% raw %}
     connectors.append(("Google Workspace", GoogleWorkspaceConnector(), {
-        "client_id": getattr(settings, "google_client_id", "") or "",
-        "client_secret": getattr(settings, "google_client_secret", "") or "",
-        "folder_id": getattr(settings, "gws_folder_id", "") or "",
+        "client_id": settings.google_client_id or "",
+        "client_secret": settings.google_client_secret or "",
+        "folder_id": settings.gws_folder_id or "",
     }))
 {% endraw %}{% elif conn == 'claude-code' %}{% raw %}
-    # Claude Code connector reads local files — no credentials needed
     connectors.append(("Claude Code", ClaudeCodeConnector(), {
-        "scope": getattr(settings, "claude_code_scope", "current"),
-        "since": getattr(settings, "claude_code_since", None),
-        "max_sessions": getattr(settings, "claude_code_max_sessions", None),
-        "content_mode": getattr(settings, "claude_code_content_mode", None),
-        "base_path": getattr(settings, "claude_code_base_path", None),
+        "scope": settings.claude_code_scope,
+        "since": settings.claude_code_since or None,
+        "max_sessions": settings.claude_code_max_sessions or None,
+        "content_mode": settings.claude_code_content_mode or None,
+        "base_path": settings.claude_code_base_path or None,
     }))
 {% endraw %}{% endif %}
 {% endfor %}
 {% raw %}
+    failed = 0
     for name, connector, creds in connectors:
         try:
             print(f"Connecting to {name}...")
@@ -117,15 +117,20 @@ def main():
             print(f"Fetching data from {name}...")
             data = connector.fetch()
 
-            for label, items in data.entities.items():
+            for label, items in data["entities"].items():
                 all_entities.setdefault(label, []).extend(items)
-            all_relationships.extend(data.relationships)
-            all_documents.extend(data.documents)
+            all_relationships.extend(data["relationships"])
+            all_documents.extend(data["documents"])
 
-            entity_count = sum(len(v) for v in data.entities.values())
-            print(f"  ✓ {name}: {entity_count} entities, {len(data.documents)} documents")
+            entity_count = sum(len(v) for v in data["entities"].values())
+            print(f"  + {name}: {entity_count} entities, {len(data['documents'])} documents")
         except Exception as e:
-            print(f"  ⚠ {name}: {e}")
+            print(f"  ! {name}: {e}", file=sys.stderr)
+            failed += 1
+
+    if not all_entities and not all_relationships:
+        print("\nNo data collected. fixtures.json not modified.", file=sys.stderr)
+        sys.exit(1)
 
     # Write results
     result = {

--- a/src/create_context_graph/templates/backend/shared/config.py.j2
+++ b/src/create_context_graph/templates/backend/shared/config.py.j2
@@ -21,6 +21,20 @@ class Settings(BaseSettings):
     linear_team: str = ""
 {% endif %}
 
+{% if 'google-workspace' in saas_connectors %}
+    google_client_id: str = ""
+    google_client_secret: str = ""
+    gws_folder_id: str = ""
+{% endif %}
+
+{% if 'claude-code' in saas_connectors %}
+    claude_code_scope: str = "current"
+    claude_code_since: str = ""
+    claude_code_max_sessions: int = 0
+    claude_code_content_mode: str = "truncated"
+    claude_code_base_path: str = ""
+{% endif %}
+
     model_config = {"env_file": "../.env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
 

--- a/src/create_context_graph/templates/base/Makefile.j2
+++ b/src/create_context_graph/templates/base/Makefile.j2
@@ -48,7 +48,7 @@ reset:
 
 # Test Neo4j connection
 test-connection:
-	@cd backend && uv run python -c "import asyncio; from app.context_graph_client import connect_neo4j, close_neo4j; asyncio.run(connect_neo4j()); print('Neo4j connection successful'); asyncio.run(close_neo4j())" \
+	@cd backend && uv run python -c "import asyncio; from app.context_graph_client import connect_neo4j; asyncio.run(connect_neo4j()); print('Neo4j connection successful')" \
 		|| echo "Connection failed. Check NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD in .env"
 
 {% if neo4j_type == 'docker' %}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -743,6 +743,86 @@ class TestClaudeCodeConnectorCLI:
         assert "file_timeline" in agent_py
         assert "my_preferences" in agent_py
 
+    def test_claude_code_config_settings_fields(self, runner, tmp_path):
+        """Generated config.py should have claude_code_* Settings fields."""
+        out = tmp_path / "cc-config"
+        result = runner.invoke(main, [
+            "cc-config",
+            "--domain", "software-engineering",
+            "--framework", "pydanticai",
+            "--connector", "claude-code",
+            "--output-dir", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        config_py = (out / "backend" / "app" / "config.py").read_text()
+        assert "claude_code_scope" in config_py
+        assert "claude_code_max_sessions" in config_py
+        assert "claude_code_content_mode" in config_py
+        assert "claude_code_base_path" in config_py
+
+    def test_claude_code_import_data_dict_access(self, runner, tmp_path):
+        """Generated import_data.py should use dict access, not attribute access."""
+        out = tmp_path / "cc-dict"
+        result = runner.invoke(main, [
+            "cc-dict",
+            "--domain", "software-engineering",
+            "--framework", "pydanticai",
+            "--connector", "claude-code",
+            "--output-dir", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        import_data = (out / "backend" / "scripts" / "import_data.py").read_text()
+        assert 'data["entities"]' in import_data
+        assert "data.entities" not in import_data
+
+    def test_claude_code_connector_entity_types(self, runner, tmp_path):
+        """Generated connector should extract all entity types including Decision/Preference."""
+        out = tmp_path / "cc-entities"
+        result = runner.invoke(main, [
+            "cc-entities",
+            "--domain", "software-engineering",
+            "--framework", "pydanticai",
+            "--connector", "claude-code",
+            "--output-dir", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        connector = (out / "backend" / "app" / "connectors" / "claude_code_connector.py").read_text()
+        for entity in ["GitBranch", "Error", "Decision", "Preference", "Alternative"]:
+            assert entity in connector, f"Missing entity type: {entity}"
+        for rel in ["ON_BRANCH", "ENCOUNTERED_ERROR", "MADE_DECISION", "CHOSE", "REJECTED",
+                     "NEXT", "PRECEDED_BY", "USED_TOOL", "EXPRESSES_PREFERENCE"]:
+            assert rel in connector, f"Missing relationship type: {rel}"
+
+    def test_claude_code_connector_has_redaction(self, runner, tmp_path):
+        """Generated connector should include secret redaction."""
+        out = tmp_path / "cc-redact"
+        result = runner.invoke(main, [
+            "cc-redact",
+            "--domain", "software-engineering",
+            "--framework", "pydanticai",
+            "--connector", "claude-code",
+            "--output-dir", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        connector = (out / "backend" / "app" / "connectors" / "claude_code_connector.py").read_text()
+        assert "REDACTED" in connector
+        assert "_SECRET_PATTERNS" in connector
+
+    def test_claude_code_scenarios_override(self, runner, tmp_path):
+        """Claude Code connector should replace generic SE scenarios with session-specific ones."""
+        out = tmp_path / "cc-scenarios"
+        result = runner.invoke(main, [
+            "cc-scenarios",
+            "--domain", "software-engineering",
+            "--framework", "pydanticai",
+            "--connector", "claude-code",
+            "--output-dir", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        frontend_config = (out / "frontend" / "lib" / "config.ts").read_text()
+        assert "Session Intelligence" in frontend_config
+        assert "pull requests" not in frontend_config.lower()
+
     def test_with_mcp_flag(self, runner, tmp_path):
         """Verify --with-mcp generates MCP config files."""
         out = tmp_path / "my-app"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -524,6 +524,35 @@ class TestProjectRenderer:
         config_py = (tmp_output / "backend" / "app" / "config.py").read_text()
         assert "session_strategy" in config_py
 
+    def test_claude_code_scenarios_override_generic(self, tmp_output):
+        """When claude-code connector is active, demo scenarios should be replaced."""
+        config = ProjectConfig(
+            project_name="cc-test",
+            domain="software-engineering",
+            framework="pydanticai",
+            saas_connectors=["claude-code"],
+        )
+        ontology = load_domain(config.domain)
+        renderer = ProjectRenderer(config, ontology)
+        ctx = renderer._context()
+
+        scenario_names = [s["name"] for s in ctx["demo_scenarios"]]
+        assert "Session Intelligence" in scenario_names
+        # Should NOT contain generic SE scenarios
+        prompts = [p for s in ctx["demo_scenarios"] for p in s["prompts"]]
+        assert not any("pull request" in p.lower() for p in prompts)
+
+    def test_no_scenario_override_without_connector(self, financial_config, tmp_output):
+        """Without claude-code connector, domain scenarios should be used as-is."""
+        ontology = load_domain(financial_config.domain)
+        renderer = ProjectRenderer(financial_config, ontology)
+        ctx = renderer._context()
+
+        # Should use the domain's own scenarios
+        assert len(ctx["demo_scenarios"]) > 0
+        scenario_names = [s["name"] for s in ctx["demo_scenarios"]]
+        assert "Session Intelligence" not in scenario_names
+
 
 class TestAllFrameworksRender:
     """Verify every agent framework template renders and compiles."""


### PR DESCRIPTION
## Summary

- Fix `make import` crash chain in scaffolded projects using `--connector claude-code` (4 bugs: `int(None)` in credentials, missing Settings fields, dict-vs-attribute access mismatch, silent empty `fixtures.json` on failure)
- Expand the scaffolded Claude Code connector from 5 to 9 entity types (adds GitBranch, Error, Decision, Preference, Alternative) with secret redaction, language detection, and message/tool call sequencing
- Replace generic software-engineering demo scenarios with Claude-Code-specific prompts when the connector is active
- Fix docs site dark-mode announcement bar, search plugin config, tutorial accuracy, domain catalog disambiguators, and custom 404 page

## What changed

### Scaffolded project fixes (blockers)
- **`claude_code_connector.py.j2`**: `int(credentials.get("max_sessions") or 0)` instead of `int(credentials.get("max_sessions", "0"))` — the `or` idiom handles explicit `None` values from `import_data.py`
- **`config.py.j2`**: Added `claude_code_scope`, `claude_code_since`, `claude_code_max_sessions`, `claude_code_content_mode`, `claude_code_base_path` Settings fields (plus `google_workspace` fields) so `.env` variables are honored instead of silently dropped by `extra: "ignore"`
- **`import_data.py.j2`**: Changed `data.entities` → `data["entities"]` (all template connectors return `dict`, not dataclass); skip writing `fixtures.json` when no data was collected; direct settings access instead of `getattr` fallbacks

### Connector feature parity (268 → 457 lines)
- **GitBranch** entities with `ON_BRANCH` relationships
- **Error** entities with `ENCOUNTERED_ERROR` relationships
- **Decision** extraction from user corrections and error-resolution cycles, with `MADE_DECISION`/`CHOSE`/`REJECTED` relationships
- **Preference** extraction from explicit statements ("always use X", "prefer X over Y"), with `EXPRESSES_PREFERENCE` relationships
- **Message sequencing** (`NEXT`) and **tool call sequencing** (`PRECEDED_BY`, `USED_TOOL`)
- **Secret redaction** for API keys, tokens, passwords, connection strings
- **Language detection** from file extensions (30+ mappings)
- **File path validation** — rejects numeric Bash arguments misinterpreted as paths
- **`[rerun: bN]`** suffix stripping from extracted content

### Renderer
- `_build_demo_scenarios()` replaces generic SE scenarios (PRs, incidents, deployments) with Claude-Code-specific prompts ("What files have I modified?", "Show me decisions", "What are my coding preferences?") when `--connector claude-code` is active

### Makefile
- `test-connection` target uses a single `asyncio.run(connect_neo4j())` instead of two sequential `asyncio.run()` calls that caused "Event loop is closed" on some platforms

### Documentation
- Tutorial: marked `ANTHROPIC_API_KEY` as required for chat, replaced "copy .env.example" with "edit the generated .env", added verification step, added `.env` settings tip for re-imports, added session deduplication note
- Dark-mode announcement bar: added CSS override so the bar isn't white-on-dark
- Search: added explicit `@easyops-cn/docusaurus-search-local` config (`hashed`, `indexDocs`, `indexBlog`)
- Intro: added CLI flag literals next to connector display names (`gcal` not "Google Calendar")
- Domain catalog: added "Focus" column with one-line disambiguators for all 22 domains
- Custom 404 page with links to Introduction, Quick Start, and "Report Broken Link"
- Homepage: "See all 22 domains →" link on carousel, tighter memory-type scroll transitions, higher-contrast step numbers at rest

### Tests (7 new, 1060 total)
- `test_claude_code_config_settings_fields` — Settings has `claude_code_*` fields
- `test_claude_code_import_data_dict_access` — `data["entities"]` not `data.entities`
- `test_claude_code_connector_entity_types` — all 5 new entity types + 9 relationship types
- `test_claude_code_connector_has_redaction` — secret redaction patterns present
- `test_claude_code_scenarios_override` — frontend config has session-specific prompts
- `test_claude_code_scenarios_override_generic` / `test_no_scenario_override_without_connector` — renderer scenario switching

## Test plan

- [x] Full unit test suite passes (1060 passed, 176 skipped)
- [x] Docs site builds without errors (`npm run build` in `docs/`)
- [x] Search index generated (`build/search-index.json`)
- [x] Scaffolded project verified: config.py fields, dict access, entity types, scenarios, Makefile
- [ ] Manual: scaffold with `--connector claude-code`, run `make install && make seed && make import`, verify no crash
- [ ] Manual: verify dark-mode announcement bar and 404 page on deployed docs
- [ ] Manual: verify search works with Cmd+K on deployed docs