### PR TITLE
GH and other connectors fixes

### DIFF
--- a/src/create_context_graph/cli.py
+++ b/src/create_context_graph/cli.py
@@ -458,22 +458,25 @@ def main(
         display_path = out.relative_to(Path.cwd())
     except ValueError:
         display_path = out
+    def _step(cmd: str, comment: str) -> None:
+        console.print(f"  [bold]{cmd}[/bold]{' ' * (18 - len(cmd))}# {comment}")
+
     console.print(f"  [bold]cd {display_path}[/bold]")
-    console.print("  [bold]make install[/bold]          # Install dependencies")
+    _step("make install",     "Install dependencies")
     if config.neo4j_type == "docker":
-        console.print("  [bold]make docker-up[/bold]       # Start Neo4j")
+        _step("make docker-up",   "Start Neo4j")
     elif config.neo4j_type == "local":
-        console.print("  [bold]make neo4j-start[/bold]     # Start Neo4j (requires Node.js)")
+        _step("make neo4j-start", "Start Neo4j (requires Node.js)")
     if config.saas_connectors:
-        console.print("  [bold]make import[/bold]           # Fetch real data from connected services")
-        console.print("  [bold]make seed[/bold]             # Apply schema + ingest data into Neo4j")
+        _step("make import",      "Fetch real data from connected services")
+        _step("make seed",        "Apply schema + ingest data into Neo4j")
     elif ingest:
-        console.print("  [bold]make seed[/bold]             # Re-seed sample data (already ingested)")
+        _step("make seed",        "Re-seed sample data (already ingested)")
     else:
-        console.print("  [bold]make seed[/bold]             # Apply schema + seed sample data")
+        _step("make seed",        "Apply schema + seed sample data")
     if config.with_mcp:
-        console.print("  [bold]make mcp-server[/bold]      # Start MCP server for Claude Desktop")
-    console.print("  [bold]make start[/bold]            # Start backend + frontend")
+        _step("make mcp-server",  "Start MCP server for Claude Desktop")
+    _step("make start",       "Start backend + frontend")
     console.print()
     console.print("  Backend:  http://localhost:8000")
     console.print("  Frontend: http://localhost:3000")

--- a/src/create_context_graph/cli.py
+++ b/src/create_context_graph/cli.py
@@ -459,20 +459,21 @@ def main(
     except ValueError:
         display_path = out
     console.print(f"  [bold]cd {display_path}[/bold]")
-    console.print("  [bold]make install[/bold]       # Install dependencies")
+    console.print("  [bold]make install[/bold]          # Install dependencies")
     if config.neo4j_type == "docker":
-        console.print("  [bold]make docker-up[/bold]    # Start Neo4j")
+        console.print("  [bold]make docker-up[/bold]       # Start Neo4j")
     elif config.neo4j_type == "local":
-        console.print("  [bold]make neo4j-start[/bold]  # Start Neo4j (requires Node.js)")
-    if ingest:
-        console.print("  [bold]make seed[/bold]          # Re-seed sample data (already ingested)")
-    else:
-        console.print("  [bold]make seed[/bold]          # Seed sample data")
+        console.print("  [bold]make neo4j-start[/bold]     # Start Neo4j (requires Node.js)")
     if config.saas_connectors:
-        console.print("  [bold]make import[/bold]         # Re-import from connected services")
+        console.print("  [bold]make import[/bold]           # Fetch real data from connected services")
+        console.print("  [bold]make seed[/bold]             # Apply schema + ingest data into Neo4j")
+    elif ingest:
+        console.print("  [bold]make seed[/bold]             # Re-seed sample data (already ingested)")
+    else:
+        console.print("  [bold]make seed[/bold]             # Apply schema + seed sample data")
     if config.with_mcp:
-        console.print("  [bold]make mcp-server[/bold]    # Start MCP server for Claude Desktop")
-    console.print("  [bold]make start[/bold]         # Start backend + frontend")
+        console.print("  [bold]make mcp-server[/bold]      # Start MCP server for Claude Desktop")
+    console.print("  [bold]make start[/bold]            # Start backend + frontend")
     console.print()
     console.print("  Backend:  http://localhost:8000")
     console.print("  Frontend: http://localhost:3000")

--- a/src/create_context_graph/connectors/gcal_connector.py
+++ b/src/create_context_graph/connectors/gcal_connector.py
@@ -118,9 +118,9 @@ class GCalConnector(BaseConnector):
             })
             relationships.append({
                 "type": "ATTENDING",
-                "source": name,
+                "source_name": name,
                 "source_label": "Person",
-                "target": summary,
+                "target_name": summary,
                 "target_label": "CalendarEvent",
             })
 
@@ -130,9 +130,9 @@ class GCalConnector(BaseConnector):
             org_name = organizer.get("displayName", org_email.split("@")[0] if org_email else "Unknown")
             relationships.append({
                 "type": "ORGANIZED",
-                "source": org_name,
+                "source_name": org_name,
                 "source_label": "Person",
-                "target": summary,
+                "target_name": summary,
                 "target_label": "CalendarEvent",
             })
 

--- a/src/create_context_graph/connectors/github_connector.py
+++ b/src/create_context_graph/connectors/github_connector.py
@@ -16,7 +16,12 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import os
+import re
+import urllib.error
+import urllib.request
 from itertools import islice
 from typing import Any
 
@@ -25,6 +30,80 @@ from create_context_graph.connectors import (
     NormalizedData,
     register_connector,
 )
+
+logger = logging.getLogger(__name__)
+
+# Matches "fixes #123", "closes #4", "resolved #12" — case-insensitive.
+_CLOSING_KEYWORD_PATTERN = re.compile(
+    r"\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+# Matches any "#123". The negative lookbehind avoids matching inside words (e.g., "abc#1").
+_REFERENCE_PATTERN = re.compile(r"(?<![A-Za-z0-9_])#(\d+)\b")
+
+_GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
+_GRAPHQL_CLOSING_ISSUES_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 50) {
+        nodes { number }
+      }
+    }
+  }
+}
+""".strip()
+
+
+def _extract_refs(text: str) -> tuple[set[int], set[int]]:
+    """Return (closes, references) sets of issue/PR numbers found in text.
+
+    A number preceded by a closing keyword (fixes/closes/resolves) goes in `closes`
+    only; all other `#N` mentions go in `references`.
+    """
+    if not text:
+        return set(), set()
+    closes = {int(m.group(1)) for m in _CLOSING_KEYWORD_PATTERN.finditer(text)}
+    references = {int(m.group(1)) for m in _REFERENCE_PATTERN.finditer(text)} - closes
+    return closes, references
+
+
+def _fetch_closing_refs_graphql(
+    token: str,
+    owner: str,
+    repo_name: str,
+    pr_number: int,
+    timeout: float = 30.0,
+) -> list[int]:
+    """Query GitHub GraphQL for authoritative closing-issue references on a PR.
+
+    Returns a list of issue numbers the PR will close when merged. On any error
+    (network, JSON, missing fields), returns an empty list and logs a warning.
+    """
+    payload = json.dumps({
+        "query": _GRAPHQL_CLOSING_ISSUES_QUERY,
+        "variables": {"owner": owner, "name": repo_name, "number": pr_number},
+    }).encode()
+    req = urllib.request.Request(
+        _GRAPHQL_ENDPOINT,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError) as exc:
+        logger.warning("GraphQL closingIssuesReferences failed for PR #%s: %s", pr_number, exc)
+        return []
+    try:
+        nodes = data["data"]["repository"]["pullRequest"]["closingIssuesReferences"]["nodes"]
+    except (KeyError, TypeError):
+        return []
+    return [n["number"] for n in nodes if n and "number" in n]
 
 
 @register_connector("github")
@@ -38,6 +117,9 @@ class GitHubConnector(BaseConnector):
     def __init__(self):
         self._client = None
         self._repo = None
+        self._token: str = ""
+        self._owner: str = ""
+        self._repo_name: str = ""
 
     def get_credential_prompts(self) -> list[dict[str, Any]]:
         return [
@@ -66,6 +148,9 @@ class GitHubConnector(BaseConnector):
 
         self._client = Github(credentials["token"])
         self._repo = self._client.get_repo(credentials["repo"])
+        self._token = credentials["token"]
+        if "/" in credentials["repo"]:
+            self._owner, self._repo_name = credentials["repo"].split("/", 1)
 
     def fetch(self, **kwargs: Any) -> NormalizedData:
         if not self._repo:
@@ -77,6 +162,11 @@ class GitHubConnector(BaseConnector):
         commits_limit = kwargs.get("commits_limit", default_limit)
         _env_import_body = os.environ.get("GITHUB_IMPORT_BODY", "true").lower() not in ("false", "0", "no")
         import_body = kwargs.get("import_body", _env_import_body)
+        _env_link = os.environ.get("GITHUB_LINK_ISSUES_PRS", "true").lower() not in ("false", "0", "no")
+        link_issues_prs = kwargs.get("link_issues_prs", _env_link)
+        link_source = kwargs.get("link_source", os.environ.get("GITHUB_LINK_SOURCE", "both")).lower()
+        if link_source not in ("regex", "graphql", "both"):
+            link_source = "both"
         entities: dict[str, list[dict]] = {
             "Person": [],
             "Organization": [],
@@ -88,6 +178,11 @@ class GitHubConnector(BaseConnector):
         relationships: list[dict] = []
         documents: list[dict] = []
         seen_users: set[str] = set()
+        # (source_name, source_label, full_text) — scanned for issue/PR refs after all entities are fetched
+        text_sources: list[tuple[str, str, str]] = []
+        # Number -> (label, name) for resolving #N references
+        number_to_entity: dict[int, tuple[str, str]] = {}
+        pr_numbers_fetched: list[int] = []
 
         # Repository entity
         repo = self._repo
@@ -154,6 +249,9 @@ class GitHubConnector(BaseConnector):
                         "author": user_name,
                     },
                 })
+            number_to_entity[issue.number] = ("Issue", issue.title)
+            if issue.body:
+                text_sources.append((issue.title, "Issue", issue.body))
 
         # Pull Requests
         for pr in islice(repo.get_pulls(state="all", sort="updated", direction="desc"), prs_limit):
@@ -184,15 +282,20 @@ class GitHubConnector(BaseConnector):
                         "author": user_name,
                     },
                 })
+            number_to_entity[pr.number] = ("PullRequest", pr.title)
+            pr_numbers_fetched.append(pr.number)
+            if pr.body:
+                text_sources.append((pr.title, "PullRequest", pr.body))
 
         # Recent commits
         for commit in islice(repo.get_commits(), commits_limit):
             author_name = "unknown"
             if commit.author:
                 author_name = _add_user(commit.author)
+            full_message = commit.commit.message or ""
             entities["Commit"].append({
                 "name": commit.sha[:8],
-                "message": commit.commit.message.split("\n")[0],
+                "message": full_message.split("\n")[0],
                 "sha": commit.sha,
                 "date": commit.commit.author.date.isoformat() if commit.commit.author.date else "",
             })
@@ -210,6 +313,8 @@ class GitHubConnector(BaseConnector):
                 "target_name":repo.full_name,
                 "target_label": "Repository",
             })
+            if full_message:
+                text_sources.append((commit.sha[:8], "Commit", full_message))
 
         # Add CONTRIBUTED_TO relationships for all users
         for user in seen_users:
@@ -220,6 +325,63 @@ class GitHubConnector(BaseConnector):
                 "target_name":repo.full_name,
                 "target_label": "Repository",
             })
+
+        # Link issues / PRs / commits via CLOSES and REFERENCES
+        if link_issues_prs:
+            # CLOSES pairs are tracked so REFERENCES is never added for the same edge,
+            # and so regex + GraphQL don't double-count the same closure.
+            closes_pairs: set[tuple[str, str, str, str]] = set()
+
+            def _add_closes(src_name: str, src_label: str, tgt_name: str, tgt_label: str) -> None:
+                key = (src_name, src_label, tgt_name, tgt_label)
+                if key in closes_pairs or (src_name, src_label) == (tgt_name, tgt_label):
+                    return
+                closes_pairs.add(key)
+                relationships.append({
+                    "type": "CLOSES",
+                    "source_name": src_name,
+                    "source_label": src_label,
+                    "target_name": tgt_name,
+                    "target_label": tgt_label,
+                })
+
+            def _add_references(src_name: str, src_label: str, tgt_name: str, tgt_label: str) -> None:
+                if (src_name, src_label, tgt_name, tgt_label) in closes_pairs:
+                    return
+                if (src_name, src_label) == (tgt_name, tgt_label):
+                    return
+                relationships.append({
+                    "type": "REFERENCES",
+                    "source_name": src_name,
+                    "source_label": src_label,
+                    "target_name": tgt_name,
+                    "target_label": tgt_label,
+                })
+
+            if link_source in ("regex", "both"):
+                for src_name, src_label, text in text_sources:
+                    closes, refs = _extract_refs(text)
+                    for num in closes:
+                        target = number_to_entity.get(num)
+                        if target:
+                            _add_closes(src_name, src_label, target[1], target[0])
+                    for num in refs:
+                        target = number_to_entity.get(num)
+                        if target:
+                            _add_references(src_name, src_label, target[1], target[0])
+
+            if link_source in ("graphql", "both") and self._token and self._owner and self._repo_name:
+                for pr_number in pr_numbers_fetched:
+                    pr_entity = number_to_entity.get(pr_number)
+                    if not pr_entity:
+                        continue
+                    closing_nums = _fetch_closing_refs_graphql(
+                        self._token, self._owner, self._repo_name, pr_number,
+                    )
+                    for issue_num in closing_nums:
+                        target = number_to_entity.get(issue_num)
+                        if target:
+                            _add_closes(pr_entity[1], pr_entity[0], target[1], target[0])
 
         return NormalizedData(
             entities=entities,

--- a/src/create_context_graph/connectors/github_connector.py
+++ b/src/create_context_graph/connectors/github_connector.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from itertools import islice
 from typing import Any
 
 from create_context_graph.connectors import (
@@ -100,9 +101,9 @@ class GitHubConnector(BaseConnector):
             })
             relationships.append({
                 "type": "BELONGS_TO",
-                "source": repo.full_name,
+                "source_name":repo.full_name,
                 "source_label": "Repository",
-                "target": repo.organization.login,
+                "target_name":repo.organization.login,
                 "target_label": "Organization",
             })
 
@@ -118,7 +119,7 @@ class GitHubConnector(BaseConnector):
             return user.login if user else "unknown"
 
         # Issues
-        for issue in repo.get_issues(state="all", sort="updated", direction="desc")[:limit]:
+        for issue in islice(repo.get_issues(state="all", sort="updated", direction="desc"), limit):
             if issue.pull_request:
                 continue  # Skip PRs in issues list
             user_name = _add_user(issue.user)
@@ -131,9 +132,9 @@ class GitHubConnector(BaseConnector):
             })
             relationships.append({
                 "type": "OPENED",
-                "source": user_name,
+                "source_name":user_name,
                 "source_label": "Person",
-                "target": issue.title,
+                "target_name":issue.title,
                 "target_label": "Issue",
             })
             if issue.body:
@@ -149,7 +150,7 @@ class GitHubConnector(BaseConnector):
                 })
 
         # Pull Requests
-        for pr in repo.get_pulls(state="all", sort="updated", direction="desc")[:limit]:
+        for pr in islice(repo.get_pulls(state="all", sort="updated", direction="desc"), limit):
             user_name = _add_user(pr.user)
             entities["PullRequest"].append({
                 "name": pr.title,
@@ -160,9 +161,9 @@ class GitHubConnector(BaseConnector):
             })
             relationships.append({
                 "type": "OPENED",
-                "source": user_name,
+                "source_name":user_name,
                 "source_label": "Person",
-                "target": pr.title,
+                "target_name":pr.title,
                 "target_label": "PullRequest",
             })
             if pr.body:
@@ -179,7 +180,7 @@ class GitHubConnector(BaseConnector):
                 })
 
         # Recent commits
-        for commit in repo.get_commits()[:min(limit, 50)]:
+        for commit in islice(repo.get_commits(), min(limit, 50)):
             author_name = "unknown"
             if commit.author:
                 author_name = _add_user(commit.author)
@@ -191,16 +192,16 @@ class GitHubConnector(BaseConnector):
             })
             relationships.append({
                 "type": "COMMITTED",
-                "source": author_name,
+                "source_name":author_name,
                 "source_label": "Person",
-                "target": commit.sha[:8],
+                "target_name":commit.sha[:8],
                 "target_label": "Commit",
             })
             relationships.append({
                 "type": "COMMITTED_TO",
-                "source": commit.sha[:8],
+                "source_name":commit.sha[:8],
                 "source_label": "Commit",
-                "target": repo.full_name,
+                "target_name":repo.full_name,
                 "target_label": "Repository",
             })
 
@@ -208,9 +209,9 @@ class GitHubConnector(BaseConnector):
         for user in seen_users:
             relationships.append({
                 "type": "CONTRIBUTED_TO",
-                "source": user,
+                "source_name":user,
                 "source_label": "Person",
-                "target": repo.full_name,
+                "target_name":repo.full_name,
                 "target_label": "Repository",
             })
 

--- a/src/create_context_graph/connectors/github_connector.py
+++ b/src/create_context_graph/connectors/github_connector.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import os
 from itertools import islice
 from typing import Any
 
@@ -74,6 +75,8 @@ class GitHubConnector(BaseConnector):
         issues_limit = kwargs.get("issues_limit", default_limit)
         prs_limit = kwargs.get("prs_limit", default_limit)
         commits_limit = kwargs.get("commits_limit", default_limit)
+        _env_import_body = os.environ.get("GITHUB_IMPORT_BODY", "true").lower() not in ("false", "0", "no")
+        import_body = kwargs.get("import_body", _env_import_body)
         entities: dict[str, list[dict]] = {
             "Person": [],
             "Organization": [],
@@ -140,11 +143,11 @@ class GitHubConnector(BaseConnector):
                 "target_name":issue.title,
                 "target_label": "Issue",
             })
-            if issue.body:
+            if import_body and issue.body:
                 documents.append({
                     "title": f"Issue #{issue.number}: {issue.title}",
                     "content": issue.body,
-                    "type": "github-issue",
+                    "type": "issue-body",
                     "metadata": {
                         "number": issue.number,
                         "state": issue.state,
@@ -169,11 +172,11 @@ class GitHubConnector(BaseConnector):
                 "target_name":pr.title,
                 "target_label": "PullRequest",
             })
-            if pr.body:
+            if import_body and pr.body:
                 documents.append({
                     "title": f"PR #{pr.number}: {pr.title}",
                     "content": pr.body,
-                    "type": "github-pr",
+                    "type": "pr-body",
                     "metadata": {
                         "number": pr.number,
                         "state": pr.state,

--- a/src/create_context_graph/connectors/github_connector.py
+++ b/src/create_context_graph/connectors/github_connector.py
@@ -70,7 +70,10 @@ class GitHubConnector(BaseConnector):
         if not self._repo:
             raise RuntimeError("Call authenticate() first")
 
-        limit = kwargs.get("limit", 100)
+        default_limit = kwargs.get("limit", 20)
+        issues_limit = kwargs.get("issues_limit", default_limit)
+        prs_limit = kwargs.get("prs_limit", default_limit)
+        commits_limit = kwargs.get("commits_limit", default_limit)
         entities: dict[str, list[dict]] = {
             "Person": [],
             "Organization": [],
@@ -119,7 +122,7 @@ class GitHubConnector(BaseConnector):
             return user.login if user else "unknown"
 
         # Issues
-        for issue in islice(repo.get_issues(state="all", sort="updated", direction="desc"), limit):
+        for issue in islice(repo.get_issues(state="all", sort="updated", direction="desc"), issues_limit):
             if issue.pull_request:
                 continue  # Skip PRs in issues list
             user_name = _add_user(issue.user)
@@ -150,7 +153,7 @@ class GitHubConnector(BaseConnector):
                 })
 
         # Pull Requests
-        for pr in islice(repo.get_pulls(state="all", sort="updated", direction="desc"), limit):
+        for pr in islice(repo.get_pulls(state="all", sort="updated", direction="desc"), prs_limit):
             user_name = _add_user(pr.user)
             entities["PullRequest"].append({
                 "name": pr.title,
@@ -180,7 +183,7 @@ class GitHubConnector(BaseConnector):
                 })
 
         # Recent commits
-        for commit in islice(repo.get_commits(), min(limit, 50)):
+        for commit in islice(repo.get_commits(), commits_limit):
             author_name = "unknown"
             if commit.author:
                 author_name = _add_user(commit.author)

--- a/src/create_context_graph/connectors/gmail_connector.py
+++ b/src/create_context_graph/connectors/gmail_connector.py
@@ -146,9 +146,9 @@ class GmailConnector(BaseConnector):
             if from_addr:
                 relationships.append({
                     "type": "SENT",
-                    "source": from_addr.split("<")[0].strip().strip('"'),
+                    "source_name": from_addr.split("<")[0].strip().strip('"'),
                     "source_label": "Person",
-                    "target": subject or f"Email {msg_id[:8]}",
+                    "target_name": subject or f"Email {msg_id[:8]}",
                     "target_label": "Email",
                 })
 
@@ -214,9 +214,9 @@ class GmailConnector(BaseConnector):
             if from_addr:
                 relationships.append({
                     "type": "SENT",
-                    "source": from_addr.split("<")[0].strip().strip('"'),
+                    "source_name": from_addr.split("<")[0].strip().strip('"'),
                     "source_label": "Person",
-                    "target": subject or f"Email {msg['id'][:8]}",
+                    "target_name": subject or f"Email {msg['id'][:8]}",
                     "target_label": "Email",
                 })
 

--- a/src/create_context_graph/connectors/jira_connector.py
+++ b/src/create_context_graph/connectors/jira_connector.py
@@ -152,9 +152,9 @@ class JiraConnector(BaseConnector):
             if assignee:
                 relationships.append({
                     "type": "ASSIGNED_TO",
-                    "source": f"{issue_key}: {summary}",
+                    "source_name": f"{issue_key}: {summary}",
                     "source_label": "Issue",
-                    "target": assignee,
+                    "target_name": assignee,
                     "target_label": "Person",
                 })
 
@@ -163,9 +163,9 @@ class JiraConnector(BaseConnector):
             if reporter:
                 relationships.append({
                     "type": "REPORTED_BY",
-                    "source": f"{issue_key}: {summary}",
+                    "source_name": f"{issue_key}: {summary}",
                     "source_label": "Issue",
-                    "target": reporter,
+                    "target_name": reporter,
                     "target_label": "Person",
                 })
 
@@ -184,18 +184,18 @@ class JiraConnector(BaseConnector):
                 if sprint_name:
                     relationships.append({
                         "type": "IN_SPRINT",
-                        "source": f"{issue_key}: {summary}",
+                        "source_name": f"{issue_key}: {summary}",
                         "source_label": "Issue",
-                        "target": sprint_name,
+                        "target_name": sprint_name,
                         "target_label": "Sprint",
                     })
 
             # Belongs to project
             relationships.append({
                 "type": "BELONGS_TO",
-                "source": f"{issue_key}: {summary}",
+                "source_name": f"{issue_key}: {summary}",
                 "source_label": "Issue",
-                "target": self._project_key,
+                "target_name": self._project_key,
                 "target_label": "Project",
             })
 

--- a/src/create_context_graph/connectors/notion_connector.py
+++ b/src/create_context_graph/connectors/notion_connector.py
@@ -133,9 +133,9 @@ class NotionConnector(BaseConnector):
                 if user_id:
                     relationships.append({
                         "type": "AUTHORED",
-                        "source": created_by.get("name", user_id),
+                        "source_name": created_by.get("name", user_id),
                         "source_label": "Person",
-                        "target": title,
+                        "target_name": title,
                         "target_label": "Page",
                     })
 
@@ -162,9 +162,9 @@ class NotionConnector(BaseConnector):
                 db_id = parent["database_id"]
                 relationships.append({
                     "type": "BELONGS_TO",
-                    "source": title,
+                    "source_name": title,
                     "source_label": "Page",
-                    "target": db_id,
+                    "target_name": db_id,
                     "target_label": "Database",
                 })
 

--- a/src/create_context_graph/connectors/salesforce_connector.py
+++ b/src/create_context_graph/connectors/salesforce_connector.py
@@ -122,9 +122,9 @@ class SalesforceConnector(BaseConnector):
             if account and account.get("Name"):
                 relationships.append({
                     "type": "WORKS_FOR",
-                    "source": name,
+                    "source_name": name,
                     "source_label": "Person",
-                    "target": account["Name"],
+                    "target_name": account["Name"],
                     "target_label": "Account",
                 })
 
@@ -144,9 +144,9 @@ class SalesforceConnector(BaseConnector):
             if account and account.get("Name"):
                 relationships.append({
                     "type": "OPPORTUNITY_FOR",
-                    "source": record.get("Name", ""),
+                    "source_name": record.get("Name", ""),
                     "source_label": "Opportunity",
-                    "target": account["Name"],
+                    "target_name": account["Name"],
                     "target_label": "Account",
                 })
 

--- a/src/create_context_graph/connectors/slack_connector.py
+++ b/src/create_context_graph/connectors/slack_connector.py
@@ -149,16 +149,16 @@ class SlackConnector(BaseConnector):
 
                 relationships.append({
                     "type": "POSTED_IN",
-                    "source": text[:80],
+                    "source_name": text[:80],
                     "source_label": "Message",
-                    "target": channel_name,
+                    "target_name": channel_name,
                     "target_label": "Channel",
                 })
                 relationships.append({
                     "type": "SENT_BY",
-                    "source": text[:80],
+                    "source_name": text[:80],
                     "source_label": "Message",
-                    "target": user_name,
+                    "target_name": user_name,
                     "target_label": "Person",
                 })
 

--- a/src/create_context_graph/renderer.py
+++ b/src/create_context_graph/renderer.py
@@ -270,6 +270,7 @@ class ProjectRenderer:
             "pydantic_models": generate_pydantic_models(self.ontology),
             "visualization": generate_visualization_config(self.ontology),
             "saas_connectors": self.config.saas_connectors,
+            "connector_credentials": self.config.saas_credentials,
             "with_mcp": self.config.with_mcp,
             "mcp_profile": self.config.mcp_profile,
             "session_strategy": self.config.session_strategy,
@@ -541,8 +542,10 @@ class ProjectRenderer:
         if base_yaml.exists():
             shutil.copy2(base_yaml, data_dir / "_base.yaml")
 
-        # Copy pre-generated fixtures if available
-        fixtures_dir = Path(str(files("create_context_graph") / "fixtures"))
-        fixture_file = fixtures_dir / f"{self.config.domain}.json"
-        if fixture_file.exists():
-            shutil.copy2(fixture_file, data_dir / "fixtures.json")
+        # Copy pre-generated fixtures only when no connectors are selected
+        # (connector projects populate fixtures.json via `make import`)
+        if not self.config.saas_connectors:
+            fixtures_dir = Path(str(files("create_context_graph") / "fixtures"))
+            fixture_file = fixtures_dir / f"{self.config.domain}.json"
+            if fixture_file.exists():
+                shutil.copy2(fixture_file, data_dir / "fixtures.json")

--- a/src/create_context_graph/templates/backend/connectors/gcal_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/gcal_connector.py.j2
@@ -102,9 +102,9 @@ class GCalConnector:
             })
             relationships.append({
                 "type": "ATTENDING",
-                "source": name,
+                "source_name": name,
                 "source_label": "Person",
-                "target": summary,
+                "target_name": summary,
                 "target_label": "CalendarEvent",
             })
 
@@ -114,9 +114,9 @@ class GCalConnector:
             org_name = organizer.get("displayName", org_email.split("@")[0] if org_email else "Unknown")
             relationships.append({
                 "type": "ORGANIZED",
-                "source": org_name,
+                "source_name": org_name,
                 "source_label": "Person",
-                "target": summary,
+                "target_name": summary,
                 "target_label": "CalendarEvent",
             })
 

--- a/src/create_context_graph/templates/backend/connectors/github_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/github_connector.py.j2
@@ -2,9 +2,78 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import os
+import re
+import urllib.error
+import urllib.request
 from itertools import islice
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CLOSING_KEYWORD_PATTERN = re.compile(
+    r"\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+_REFERENCE_PATTERN = re.compile(r"(?<![A-Za-z0-9_])#(\d+)\b")
+
+_GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
+_GRAPHQL_CLOSING_ISSUES_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 50) {
+        nodes { number }
+      }
+    }
+  }
+}
+""".strip()
+
+
+def _extract_refs(text: str) -> tuple[set[int], set[int]]:
+    """Return (closes, references) sets of issue/PR numbers mentioned in text."""
+    if not text:
+        return set(), set()
+    closes = {int(m.group(1)) for m in _CLOSING_KEYWORD_PATTERN.finditer(text)}
+    references = {int(m.group(1)) for m in _REFERENCE_PATTERN.finditer(text)} - closes
+    return closes, references
+
+
+def _fetch_closing_refs_graphql(
+    token: str,
+    owner: str,
+    repo_name: str,
+    pr_number: int,
+    timeout: float = 30.0,
+) -> list[int]:
+    """Query GitHub GraphQL for a PR's authoritative closing-issue references."""
+    payload = json.dumps({
+        "query": _GRAPHQL_CLOSING_ISSUES_QUERY,
+        "variables": {"owner": owner, "name": repo_name, "number": pr_number},
+    }).encode()
+    req = urllib.request.Request(
+        _GRAPHQL_ENDPOINT,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError) as exc:
+        logger.warning("GraphQL closingIssuesReferences failed for PR #%s: %s", pr_number, exc)
+        return []
+    try:
+        nodes = data["data"]["repository"]["pullRequest"]["closingIssuesReferences"]["nodes"]
+    except (KeyError, TypeError):
+        return []
+    return [n["number"] for n in nodes if n and "number" in n]
 
 
 class GitHubConnector:
@@ -13,6 +82,9 @@ class GitHubConnector:
     def __init__(self):
         self._client = None
         self._repo = None
+        self._token: str = ""
+        self._owner: str = ""
+        self._repo_name: str = ""
 
     def authenticate(self, credentials: dict[str, str]) -> None:
         """Authenticate with GitHub.
@@ -31,6 +103,9 @@ class GitHubConnector:
 
         self._client = Github(credentials["token"])
         self._repo = self._client.get_repo(credentials["repo"])
+        self._token = credentials["token"]
+        if "/" in credentials["repo"]:
+            self._owner, self._repo_name = credentials["repo"].split("/", 1)
 
     def fetch(self, **kwargs: Any) -> dict:
         """Fetch issues, PRs, commits, and contributors.
@@ -47,6 +122,11 @@ class GitHubConnector:
         commits_limit = kwargs.get("commits_limit", default_limit)
         _env_import_body = os.environ.get("GITHUB_IMPORT_BODY", "true").lower() not in ("false", "0", "no")
         import_body = kwargs.get("import_body", _env_import_body)
+        _env_link = os.environ.get("GITHUB_LINK_ISSUES_PRS", "true").lower() not in ("false", "0", "no")
+        link_issues_prs = kwargs.get("link_issues_prs", _env_link)
+        link_source = kwargs.get("link_source", os.environ.get("GITHUB_LINK_SOURCE", "both")).lower()
+        if link_source not in ("regex", "graphql", "both"):
+            link_source = "both"
         entities: dict[str, list[dict]] = {
             "Person": [],
             "Organization": [],
@@ -58,6 +138,9 @@ class GitHubConnector:
         relationships: list[dict] = []
         documents: list[dict] = []
         seen_users: set[str] = set()
+        text_sources: list[tuple[str, str, str]] = []
+        number_to_entity: dict[int, tuple[str, str]] = {}
+        pr_numbers_fetched: list[int] = []
 
         repo = self._repo
 
@@ -125,6 +208,9 @@ class GitHubConnector:
                         "author": user_name,
                     },
                 })
+            number_to_entity[issue.number] = ("Issue", issue.title)
+            if issue.body:
+                text_sources.append((issue.title, "Issue", issue.body))
 
         # Pull Requests
         for pr in islice(repo.get_pulls(state="all", sort="updated", direction="desc"), prs_limit):
@@ -155,15 +241,20 @@ class GitHubConnector:
                         "author": user_name,
                     },
                 })
+            number_to_entity[pr.number] = ("PullRequest", pr.title)
+            pr_numbers_fetched.append(pr.number)
+            if pr.body:
+                text_sources.append((pr.title, "PullRequest", pr.body))
 
         # Recent commits
         for commit in islice(repo.get_commits(), commits_limit):
             author_name = "unknown"
             if commit.author:
                 author_name = _add_user(commit.author)
+            full_message = commit.commit.message or ""
             entities["Commit"].append({
                 "name": commit.sha[:8],
-                "message": commit.commit.message.split("\n")[0],
+                "message": full_message.split("\n")[0],
                 "sha": commit.sha,
                 "date": commit.commit.author.date.isoformat() if commit.commit.author.date else "",
             })
@@ -181,6 +272,8 @@ class GitHubConnector:
                 "target_name":repo.full_name,
                 "target_label": "Repository",
             })
+            if full_message:
+                text_sources.append((commit.sha[:8], "Commit", full_message))
 
         # CONTRIBUTED_TO relationships for all users
         for user in seen_users:
@@ -191,6 +284,61 @@ class GitHubConnector:
                 "target_name":repo.full_name,
                 "target_label": "Repository",
             })
+
+        # Link issues / PRs / commits via CLOSES and REFERENCES
+        if link_issues_prs:
+            closes_pairs: set[tuple[str, str, str, str]] = set()
+
+            def _add_closes(src_name: str, src_label: str, tgt_name: str, tgt_label: str) -> None:
+                key = (src_name, src_label, tgt_name, tgt_label)
+                if key in closes_pairs or (src_name, src_label) == (tgt_name, tgt_label):
+                    return
+                closes_pairs.add(key)
+                relationships.append({
+                    "type": "CLOSES",
+                    "source_name": src_name,
+                    "source_label": src_label,
+                    "target_name": tgt_name,
+                    "target_label": tgt_label,
+                })
+
+            def _add_references(src_name: str, src_label: str, tgt_name: str, tgt_label: str) -> None:
+                if (src_name, src_label, tgt_name, tgt_label) in closes_pairs:
+                    return
+                if (src_name, src_label) == (tgt_name, tgt_label):
+                    return
+                relationships.append({
+                    "type": "REFERENCES",
+                    "source_name": src_name,
+                    "source_label": src_label,
+                    "target_name": tgt_name,
+                    "target_label": tgt_label,
+                })
+
+            if link_source in ("regex", "both"):
+                for src_name, src_label, text in text_sources:
+                    closes, refs = _extract_refs(text)
+                    for num in closes:
+                        target = number_to_entity.get(num)
+                        if target:
+                            _add_closes(src_name, src_label, target[1], target[0])
+                    for num in refs:
+                        target = number_to_entity.get(num)
+                        if target:
+                            _add_references(src_name, src_label, target[1], target[0])
+
+            if link_source in ("graphql", "both") and self._token and self._owner and self._repo_name:
+                for pr_number in pr_numbers_fetched:
+                    pr_entity = number_to_entity.get(pr_number)
+                    if not pr_entity:
+                        continue
+                    closing_nums = _fetch_closing_refs_graphql(
+                        self._token, self._owner, self._repo_name, pr_number,
+                    )
+                    for issue_num in closing_nums:
+                        target = number_to_entity.get(issue_num)
+                        if target:
+                            _add_closes(pr_entity[1], pr_entity[0], target[1], target[0])
 
         return {
             "entities": entities,

--- a/src/create_context_graph/templates/backend/connectors/github_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/github_connector.py.j2
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from itertools import islice
 from typing import Any
 
 
@@ -71,9 +72,9 @@ class GitHubConnector:
             })
             relationships.append({
                 "type": "BELONGS_TO",
-                "source": repo.full_name,
+                "source_name":repo.full_name,
                 "source_label": "Repository",
-                "target": repo.organization.login,
+                "target_name":repo.organization.login,
                 "target_label": "Organization",
             })
 
@@ -89,7 +90,7 @@ class GitHubConnector:
             return user.login if user else "unknown"
 
         # Issues
-        for issue in repo.get_issues(state="all", sort="updated", direction="desc")[:limit]:
+        for issue in islice(repo.get_issues(state="all", sort="updated", direction="desc"), limit):
             if issue.pull_request:
                 continue
             user_name = _add_user(issue.user)
@@ -102,9 +103,9 @@ class GitHubConnector:
             })
             relationships.append({
                 "type": "OPENED",
-                "source": user_name,
+                "source_name":user_name,
                 "source_label": "Person",
-                "target": issue.title,
+                "target_name":issue.title,
                 "target_label": "Issue",
             })
             if issue.body:
@@ -120,7 +121,7 @@ class GitHubConnector:
                 })
 
         # Pull Requests
-        for pr in repo.get_pulls(state="all", sort="updated", direction="desc")[:limit]:
+        for pr in islice(repo.get_pulls(state="all", sort="updated", direction="desc"), limit):
             user_name = _add_user(pr.user)
             entities["PullRequest"].append({
                 "name": pr.title,
@@ -131,9 +132,9 @@ class GitHubConnector:
             })
             relationships.append({
                 "type": "OPENED",
-                "source": user_name,
+                "source_name":user_name,
                 "source_label": "Person",
-                "target": pr.title,
+                "target_name":pr.title,
                 "target_label": "PullRequest",
             })
             if pr.body:
@@ -150,7 +151,7 @@ class GitHubConnector:
                 })
 
         # Recent commits
-        for commit in repo.get_commits()[:min(limit, 50)]:
+        for commit in islice(repo.get_commits(), min(limit, 50)):
             author_name = "unknown"
             if commit.author:
                 author_name = _add_user(commit.author)
@@ -162,16 +163,16 @@ class GitHubConnector:
             })
             relationships.append({
                 "type": "COMMITTED",
-                "source": author_name,
+                "source_name":author_name,
                 "source_label": "Person",
-                "target": commit.sha[:8],
+                "target_name":commit.sha[:8],
                 "target_label": "Commit",
             })
             relationships.append({
                 "type": "COMMITTED_TO",
-                "source": commit.sha[:8],
+                "source_name":commit.sha[:8],
                 "source_label": "Commit",
-                "target": repo.full_name,
+                "target_name":repo.full_name,
                 "target_label": "Repository",
             })
 
@@ -179,9 +180,9 @@ class GitHubConnector:
         for user in seen_users:
             relationships.append({
                 "type": "CONTRIBUTED_TO",
-                "source": user,
+                "source_name":user,
                 "source_label": "Person",
-                "target": repo.full_name,
+                "target_name":repo.full_name,
                 "target_label": "Repository",
             })
 

--- a/src/create_context_graph/templates/backend/connectors/github_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/github_connector.py.j2
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from itertools import islice
 from typing import Any
 
@@ -44,6 +45,8 @@ class GitHubConnector:
         issues_limit = kwargs.get("issues_limit", default_limit)
         prs_limit = kwargs.get("prs_limit", default_limit)
         commits_limit = kwargs.get("commits_limit", default_limit)
+        _env_import_body = os.environ.get("GITHUB_IMPORT_BODY", "true").lower() not in ("false", "0", "no")
+        import_body = kwargs.get("import_body", _env_import_body)
         entities: dict[str, list[dict]] = {
             "Person": [],
             "Organization": [],
@@ -111,11 +114,11 @@ class GitHubConnector:
                 "target_name":issue.title,
                 "target_label": "Issue",
             })
-            if issue.body:
+            if import_body and issue.body:
                 documents.append({
                     "title": f"Issue #{issue.number}: {issue.title}",
                     "content": issue.body,
-                    "type": "github-issue",
+                    "type": "issue-body",
                     "metadata": {
                         "number": issue.number,
                         "state": issue.state,
@@ -140,11 +143,11 @@ class GitHubConnector:
                 "target_name":pr.title,
                 "target_label": "PullRequest",
             })
-            if pr.body:
+            if import_body and pr.body:
                 documents.append({
                     "title": f"PR #{pr.number}: {pr.title}",
                     "content": pr.body,
-                    "type": "github-pr",
+                    "type": "pr-body",
                     "metadata": {
                         "number": pr.number,
                         "state": pr.state,

--- a/src/create_context_graph/templates/backend/connectors/github_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/github_connector.py.j2
@@ -40,7 +40,10 @@ class GitHubConnector:
         if not self._repo:
             raise RuntimeError("Call authenticate() first")
 
-        limit = kwargs.get("limit", 100)
+        default_limit = kwargs.get("limit", 20)
+        issues_limit = kwargs.get("issues_limit", default_limit)
+        prs_limit = kwargs.get("prs_limit", default_limit)
+        commits_limit = kwargs.get("commits_limit", default_limit)
         entities: dict[str, list[dict]] = {
             "Person": [],
             "Organization": [],
@@ -90,7 +93,7 @@ class GitHubConnector:
             return user.login if user else "unknown"
 
         # Issues
-        for issue in islice(repo.get_issues(state="all", sort="updated", direction="desc"), limit):
+        for issue in islice(repo.get_issues(state="all", sort="updated", direction="desc"), issues_limit):
             if issue.pull_request:
                 continue
             user_name = _add_user(issue.user)
@@ -121,7 +124,7 @@ class GitHubConnector:
                 })
 
         # Pull Requests
-        for pr in islice(repo.get_pulls(state="all", sort="updated", direction="desc"), limit):
+        for pr in islice(repo.get_pulls(state="all", sort="updated", direction="desc"), prs_limit):
             user_name = _add_user(pr.user)
             entities["PullRequest"].append({
                 "name": pr.title,
@@ -151,7 +154,7 @@ class GitHubConnector:
                 })
 
         # Recent commits
-        for commit in islice(repo.get_commits(), min(limit, 50)):
+        for commit in islice(repo.get_commits(), commits_limit):
             author_name = "unknown"
             if commit.author:
                 author_name = _add_user(commit.author)

--- a/src/create_context_graph/templates/backend/connectors/gmail_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/gmail_connector.py.j2
@@ -129,9 +129,9 @@ class GmailConnector:
             if from_addr:
                 relationships.append({
                     "type": "SENT",
-                    "source": from_addr.split("<")[0].strip().strip('"'),
+                    "source_name": from_addr.split("<")[0].strip().strip('"'),
                     "source_label": "Person",
-                    "target": subject or f"Email {msg_id[:8]}",
+                    "target_name": subject or f"Email {msg_id[:8]}",
                     "target_label": "Email",
                 })
 
@@ -197,9 +197,9 @@ class GmailConnector:
             if from_addr:
                 relationships.append({
                     "type": "SENT",
-                    "source": from_addr.split("<")[0].strip().strip('"'),
+                    "source_name": from_addr.split("<")[0].strip().strip('"'),
                     "source_label": "Person",
-                    "target": subject or f"Email {msg['id'][:8]}",
+                    "target_name": subject or f"Email {msg['id'][:8]}",
                     "target_label": "Email",
                 })
 

--- a/src/create_context_graph/templates/backend/connectors/import_data.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/import_data.py.j2
@@ -58,6 +58,9 @@ def main():
             "issues_limit": settings.github_issues_limit or settings.github_limit,
             "prs_limit": settings.github_prs_limit or settings.github_limit,
             "commits_limit": settings.github_commits_limit or settings.github_limit,
+            "import_body": settings.github_import_body,
+            "link_issues_prs": settings.github_link_issues_prs,
+            "link_source": settings.github_link_source,
         }))
 {% endraw %}{% elif conn == 'notion' %}{% raw %}
     if settings.notion_token:

--- a/src/create_context_graph/templates/backend/connectors/import_data.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/import_data.py.j2
@@ -54,12 +54,16 @@ def main():
         connectors.append(("GitHub", GitHubConnector(), {
             "token": settings.github_token,
             "repo": settings.github_repo,
+        }, {
+            "issues_limit": settings.github_issues_limit or settings.github_limit,
+            "prs_limit": settings.github_prs_limit or settings.github_limit,
+            "commits_limit": settings.github_commits_limit or settings.github_limit,
         }))
 {% endraw %}{% elif conn == 'notion' %}{% raw %}
     if settings.notion_token:
         connectors.append(("Notion", NotionConnector(), {
             "token": settings.notion_token,
-        }))
+        }, {}))
 {% endraw %}{% elif conn == 'jira' %}{% raw %}
     if settings.jira_url and settings.jira_email and settings.jira_token:
         connectors.append(("Jira", JiraConnector(), {
@@ -67,17 +71,17 @@ def main():
             "email": settings.jira_email,
             "token": settings.jira_token,
             "project": settings.jira_project,
-        }))
+        }, {}))
 {% endraw %}{% elif conn == 'slack' %}{% raw %}
     if settings.slack_token:
         connectors.append(("Slack", SlackConnector(), {
             "token": settings.slack_token,
             "channels": settings.slack_channels or "all",
-        }))
+        }, {}))
 {% endraw %}{% elif conn == 'gmail' %}{% raw %}
-    connectors.append(("Gmail", GmailConnector(), {}))
+    connectors.append(("Gmail", GmailConnector(), {}, {}))
 {% endraw %}{% elif conn == 'gcal' %}{% raw %}
-    connectors.append(("Google Calendar", GCalConnector(), {}))
+    connectors.append(("Google Calendar", GCalConnector(), {}, {}))
 {% endraw %}{% elif conn == 'salesforce' %}{% raw %}
     if settings.salesforce_username and settings.salesforce_password:
         connectors.append(("Salesforce", SalesforceConnector(), {
@@ -85,19 +89,19 @@ def main():
             "password": settings.salesforce_password,
             "security_token": settings.salesforce_security_token or "",
             "domain": settings.salesforce_domain or "login",
-        }))
+        }, {}))
 {% endraw %}{% elif conn == 'linear' %}{% raw %}
     if settings.linear_api_key:
         connectors.append(("Linear", LinearConnector(), {
             "api_key": settings.linear_api_key,
             "team_key": settings.linear_team or "",
-        }))
+        }, {}))
 {% endraw %}{% elif conn == 'google-workspace' %}{% raw %}
     connectors.append(("Google Workspace", GoogleWorkspaceConnector(), {
         "client_id": settings.google_client_id or "",
         "client_secret": settings.google_client_secret or "",
         "folder_id": settings.gws_folder_id or "",
-    }))
+    }, {}))
 {% endraw %}{% elif conn == 'claude-code' %}{% raw %}
     connectors.append(("Claude Code", ClaudeCodeConnector(), {
         "scope": settings.claude_code_scope,
@@ -105,17 +109,17 @@ def main():
         "max_sessions": settings.claude_code_max_sessions or None,
         "content_mode": settings.claude_code_content_mode or None,
         "base_path": settings.claude_code_base_path or None,
-    }))
+    }, {}))
 {% endraw %}{% endif %}
 {% endfor %}
 {% raw %}
     failed = 0
-    for name, connector, creds in connectors:
+    for name, connector, creds, fetch_kwargs in connectors:
         try:
             print(f"Connecting to {name}...")
             connector.authenticate(creds)
             print(f"Fetching data from {name}...")
-            data = connector.fetch()
+            data = connector.fetch(**fetch_kwargs)
 
             for label, items in data["entities"].items():
                 all_entities.setdefault(label, []).extend(items)

--- a/src/create_context_graph/templates/backend/connectors/jira_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/jira_connector.py.j2
@@ -109,9 +109,9 @@ class JiraConnector:
             if assignee:
                 relationships.append({
                     "type": "ASSIGNED_TO",
-                    "source": f"{issue_key}: {summary}",
+                    "source_name": f"{issue_key}: {summary}",
                     "source_label": "Issue",
-                    "target": assignee,
+                    "target_name": assignee,
                     "target_label": "Person",
                 })
 
@@ -120,9 +120,9 @@ class JiraConnector:
             if reporter:
                 relationships.append({
                     "type": "REPORTED_BY",
-                    "source": f"{issue_key}: {summary}",
+                    "source_name": f"{issue_key}: {summary}",
                     "source_label": "Issue",
-                    "target": reporter,
+                    "target_name": reporter,
                     "target_label": "Person",
                 })
 
@@ -141,18 +141,18 @@ class JiraConnector:
                 if sprint_name:
                     relationships.append({
                         "type": "IN_SPRINT",
-                        "source": f"{issue_key}: {summary}",
+                        "source_name": f"{issue_key}: {summary}",
                         "source_label": "Issue",
-                        "target": sprint_name,
+                        "target_name": sprint_name,
                         "target_label": "Sprint",
                     })
 
             # Belongs to project
             relationships.append({
                 "type": "BELONGS_TO",
-                "source": f"{issue_key}: {summary}",
+                "source_name": f"{issue_key}: {summary}",
                 "source_label": "Issue",
-                "target": self._project_key,
+                "target_name": self._project_key,
                 "target_label": "Project",
             })
 

--- a/src/create_context_graph/templates/backend/connectors/notion_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/notion_connector.py.j2
@@ -108,9 +108,9 @@ class NotionConnector:
                 if user_id:
                     relationships.append({
                         "type": "AUTHORED",
-                        "source": created_by.get("name", user_id),
+                        "source_name": created_by.get("name", user_id),
                         "source_label": "Person",
-                        "target": title,
+                        "target_name": title,
                         "target_label": "Page",
                     })
 
@@ -137,9 +137,9 @@ class NotionConnector:
                 db_id = parent["database_id"]
                 relationships.append({
                     "type": "BELONGS_TO",
-                    "source": title,
+                    "source_name": title,
                     "source_label": "Page",
-                    "target": db_id,
+                    "target_name": db_id,
                     "target_label": "Database",
                 })
 

--- a/src/create_context_graph/templates/backend/connectors/salesforce_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/salesforce_connector.py.j2
@@ -89,9 +89,9 @@ class SalesforceConnector:
             if account and account.get("Name"):
                 relationships.append({
                     "type": "WORKS_FOR",
-                    "source": name,
+                    "source_name": name,
                     "source_label": "Person",
-                    "target": account["Name"],
+                    "target_name": account["Name"],
                     "target_label": "Account",
                 })
 
@@ -116,9 +116,9 @@ class SalesforceConnector:
             if account and account.get("Name"):
                 relationships.append({
                     "type": "OPPORTUNITY_FOR",
-                    "source": record.get("Name", ""),
+                    "source_name": record.get("Name", ""),
                     "source_label": "Opportunity",
-                    "target": account["Name"],
+                    "target_name": account["Name"],
                     "target_label": "Account",
                 })
 

--- a/src/create_context_graph/templates/backend/connectors/slack_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/slack_connector.py.j2
@@ -120,16 +120,16 @@ class SlackConnector:
 
                 relationships.append({
                     "type": "POSTED_IN",
-                    "source": text[:80],
+                    "source_name": text[:80],
                     "source_label": "Message",
-                    "target": channel_name,
+                    "target_name": channel_name,
                     "target_label": "Channel",
                 })
                 relationships.append({
                     "type": "SENT_BY",
-                    "source": text[:80],
+                    "source_name": text[:80],
                     "source_label": "Message",
-                    "target": user_name,
+                    "target_name": user_name,
                     "target_label": "Person",
                 })
 

--- a/src/create_context_graph/templates/backend/shared/config.py.j2
+++ b/src/create_context_graph/templates/backend/shared/config.py.j2
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     github_issues_limit: int = 0  # 0 = use github_limit
     github_prs_limit: int = 0
     github_commits_limit: int = 0
+    github_import_body: bool = True
+    github_link_issues_prs: bool = True
+    github_link_source: str = "both"  # regex | graphql | both
 {% endif %}
 
 {% if 'notion' in saas_connectors %}

--- a/src/create_context_graph/templates/backend/shared/config.py.j2
+++ b/src/create_context_graph/templates/backend/shared/config.py.j2
@@ -16,6 +16,34 @@ class Settings(BaseSettings):
     backend_port: int = 8000
     frontend_port: int = 3000
 
+{% if 'github' in saas_connectors %}
+    github_token: str = ""
+    github_repo: str = ""
+{% endif %}
+
+{% if 'notion' in saas_connectors %}
+    notion_token: str = ""
+{% endif %}
+
+{% if 'jira' in saas_connectors %}
+    jira_url: str = ""
+    jira_email: str = ""
+    jira_token: str = ""
+    jira_project: str = ""
+{% endif %}
+
+{% if 'slack' in saas_connectors %}
+    slack_token: str = ""
+    slack_channels: str = ""
+{% endif %}
+
+{% if 'salesforce' in saas_connectors %}
+    salesforce_username: str = ""
+    salesforce_password: str = ""
+    salesforce_security_token: str = ""
+    salesforce_domain: str = "login"
+{% endif %}
+
 {% if 'linear' in saas_connectors %}
     linear_api_key: str = ""
     linear_team: str = ""

--- a/src/create_context_graph/templates/backend/shared/config.py.j2
+++ b/src/create_context_graph/templates/backend/shared/config.py.j2
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
 {% if 'github' in saas_connectors %}
     github_token: str = ""
     github_repo: str = ""
+    github_limit: int = 20
+    github_issues_limit: int = 0  # 0 = use github_limit
+    github_prs_limit: int = 0
+    github_commits_limit: int = 0
 {% endif %}
 
 {% if 'notion' in saas_connectors %}

--- a/src/create_context_graph/templates/backend/shared/memory.py.j2
+++ b/src/create_context_graph/templates/backend/shared/memory.py.j2
@@ -34,15 +34,15 @@ async def connect_memory() -> None:
             session_strategy=strategy_map.get(
                 settings.session_strategy, SessionStrategy.PER_CONVERSATION
             ),
-            auto_extract={{ auto_extract | tojson }},
-            auto_preferences={{ auto_preferences | tojson }},
+            auto_extract={{ auto_extract | capitalize }},
+            auto_preferences={{ auto_preferences | capitalize }},
         )
         await _memory.connect()
         logger.info(
             "MemoryIntegration connected (strategy=%s, extract=%s, preferences=%s)",
             settings.session_strategy,
-            {{ auto_extract | tojson }},
-            {{ auto_preferences | tojson }},
+            {{ auto_extract | capitalize }},
+            {{ auto_preferences | capitalize }},
         )
     except ImportError:
         logger.info("neo4j-agent-memory not installed — memory disabled")

--- a/src/create_context_graph/templates/backend/shared/pyproject.toml.j2
+++ b/src/create_context_graph/templates/backend/shared/pyproject.toml.j2
@@ -18,6 +18,25 @@ dependencies = [
 {% for dep in framework_deps %}
     "{{ dep }}",
 {% endfor %}
+{% if 'github' in saas_connectors %}
+    "PyGithub>=2.0",
+{% endif %}
+{% if 'notion' in saas_connectors %}
+    "notion-client>=2.0",
+{% endif %}
+{% if 'jira' in saas_connectors %}
+    "atlassian-python-api>=3.0",
+{% endif %}
+{% if 'slack' in saas_connectors %}
+    "slack-sdk>=3.0",
+{% endif %}
+{% if 'salesforce' in saas_connectors %}
+    "simple-salesforce>=1.0",
+{% endif %}
+{% if 'gmail' in saas_connectors or 'gcal' in saas_connectors or 'google-workspace' in saas_connectors %}
+    "google-api-python-client>=2.0",
+    "google-auth-oauthlib>=1.0",
+{% endif %}
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/create_context_graph/templates/base/Makefile.j2
+++ b/src/create_context_graph/templates/base/Makefile.j2
@@ -4,7 +4,7 @@
 -include .env
 export
 
-.PHONY: start dev dev-backend dev-frontend install seed reset test-connection clean test test-e2e lint docker-build docker-prod-up docker-prod-down
+.PHONY: start dev dev-backend dev-frontend install schema seed reset test-connection clean test test-e2e lint docker-build docker-prod-up docker-prod-down
 
 # Start both backend and frontend
 start:
@@ -38,7 +38,11 @@ install-frontend:
 # Install everything
 install: install-backend install-frontend
 
-# Seed data into Neo4j
+# Apply Neo4j schema constraints and indexes only (no data)
+schema:
+	cd backend && uv run python -c "import asyncio; from scripts.generate_data import apply_schema; asyncio.run(apply_schema())"
+
+# Apply schema and ingest fixtures.json into Neo4j (real data if present, otherwise dummy data)
 seed:
 	cd backend && uv run python scripts/generate_data.py
 
@@ -84,12 +88,13 @@ mcp-server:  ## Start MCP server for Claude Desktop
 {% endif %}
 
 {% if saas_connectors %}
-# Data import from connected services
+# Fetch real data from connected services into data/fixtures.json
 import:
 	cd backend && uv run python scripts/import_data.py
 
+# Fetch real data and ingest it into Neo4j (schema + import + seed in one step)
 import-and-seed: import
-	cd backend && uv run python scripts/generate_data.py --ingest
+	cd backend && uv run python scripts/generate_data.py
 {% endif %}
 
 # Test

--- a/src/create_context_graph/templates/base/dot_env.j2
+++ b/src/create_context_graph/templates/base/dot_env.j2
@@ -24,6 +24,9 @@ GITHUB_LIMIT=20
 # GITHUB_ISSUES_LIMIT=20   # Override GITHUB_LIMIT for issues only
 # GITHUB_PRS_LIMIT=20      # Override GITHUB_LIMIT for pull requests only
 # GITHUB_COMMITS_LIMIT=20  # Override GITHUB_LIMIT for commits only
+GITHUB_IMPORT_BODY=true    # Store issue/PR bodies as Documents
+GITHUB_LINK_ISSUES_PRS=true  # Detect CLOSES/REFERENCES links between issues, PRs, and commits
+GITHUB_LINK_SOURCE=both    # regex | graphql | both (regex scans bodies; graphql queries closingIssuesReferences per PR)
 {% endif %}
 {% if 'notion' in saas_connectors %}
 # Notion (knowledge base import)

--- a/src/create_context_graph/templates/base/dot_env.j2
+++ b/src/create_context_graph/templates/base/dot_env.j2
@@ -16,16 +16,42 @@ DOMAIN_ID={{ domain.id }}
 BACKEND_PORT=8000
 FRONTEND_PORT=3000
 
+{% if 'github' in saas_connectors %}
+# GitHub (repository data import)
+GITHUB_TOKEN={{ connector_credentials.get('github', {}).get('token', '') }}
+GITHUB_REPO={{ connector_credentials.get('github', {}).get('repo', '') }}
+{% endif %}
+{% if 'notion' in saas_connectors %}
+# Notion (knowledge base import)
+NOTION_TOKEN={{ connector_credentials.get('notion', {}).get('token', '') }}
+{% endif %}
+{% if 'jira' in saas_connectors %}
+# Jira (issue tracking import)
+JIRA_URL={{ connector_credentials.get('jira', {}).get('url', '') }}
+JIRA_EMAIL={{ connector_credentials.get('jira', {}).get('email', '') }}
+JIRA_TOKEN={{ connector_credentials.get('jira', {}).get('token', '') }}
+JIRA_PROJECT={{ connector_credentials.get('jira', {}).get('project', '') }}
+{% endif %}
+{% if 'slack' in saas_connectors %}
+# Slack (channel history import)
+SLACK_TOKEN={{ connector_credentials.get('slack', {}).get('token', '') }}
+{% endif %}
+{% if 'salesforce' in saas_connectors %}
+# Salesforce (CRM data import)
+SALESFORCE_USERNAME={{ connector_credentials.get('salesforce', {}).get('username', '') }}
+SALESFORCE_PASSWORD={{ connector_credentials.get('salesforce', {}).get('password', '') }}
+SALESFORCE_SECURITY_TOKEN={{ connector_credentials.get('salesforce', {}).get('security_token', '') }}
+{% endif %}
 {% if 'linear' in saas_connectors %}
-# Linear (project management data import)
-LINEAR_API_KEY=
-LINEAR_TEAM=
+# Linear (project management import)
+LINEAR_API_KEY={{ connector_credentials.get('linear', {}).get('api_key', '') }}
+LINEAR_TEAM={{ connector_credentials.get('linear', {}).get('team_key', '') }}
 {% endif %}
 {% if 'google-workspace' in saas_connectors %}
 # Google Workspace (decision trace import)
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-GWS_FOLDER_ID=
+GOOGLE_CLIENT_ID={{ connector_credentials.get('google-workspace', {}).get('client_id', '') }}
+GOOGLE_CLIENT_SECRET={{ connector_credentials.get('google-workspace', {}).get('client_secret', '') }}
+GWS_FOLDER_ID={{ connector_credentials.get('google-workspace', {}).get('folder_id', '') }}
 {% endif %}
 # Suppress HuggingFace Hub warnings (set HF_TOKEN for higher rate limits)
 HF_HUB_DISABLE_TELEMETRY=1

--- a/src/create_context_graph/templates/base/dot_env.j2
+++ b/src/create_context_graph/templates/base/dot_env.j2
@@ -20,6 +20,10 @@ FRONTEND_PORT=3000
 # GitHub (repository data import)
 GITHUB_TOKEN={{ connector_credentials.get('github', {}).get('token', '') }}
 GITHUB_REPO={{ connector_credentials.get('github', {}).get('repo', '') }}
+GITHUB_LIMIT=20
+# GITHUB_ISSUES_LIMIT=20   # Override GITHUB_LIMIT for issues only
+# GITHUB_PRS_LIMIT=20      # Override GITHUB_LIMIT for pull requests only
+# GITHUB_COMMITS_LIMIT=20  # Override GITHUB_LIMIT for commits only
 {% endif %}
 {% if 'notion' in saas_connectors %}
 # Notion (knowledge base import)

--- a/src/create_context_graph/templates/base/dot_env_example.j2
+++ b/src/create_context_graph/templates/base/dot_env_example.j2
@@ -30,6 +30,9 @@ GITHUB_LIMIT=20                    # Default max for issues, PRs, and commits
 # GITHUB_ISSUES_LIMIT=20           # Override GITHUB_LIMIT for issues only
 # GITHUB_PRS_LIMIT=20              # Override GITHUB_LIMIT for pull requests only
 # GITHUB_COMMITS_LIMIT=20          # Override GITHUB_LIMIT for commits only
+GITHUB_IMPORT_BODY=true            # Store issue/PR bodies as Documents
+GITHUB_LINK_ISSUES_PRS=true        # Detect CLOSES/REFERENCES links between issues, PRs, and commits
+GITHUB_LINK_SOURCE=both            # regex | graphql | both (regex scans bodies; graphql queries closingIssuesReferences per PR)
 {% endif %}
 {% if 'notion' in saas_connectors %}
 # Notion (knowledge base import)

--- a/src/create_context_graph/templates/base/dot_env_example.j2
+++ b/src/create_context_graph/templates/base/dot_env_example.j2
@@ -22,8 +22,34 @@ SESSION_STRATEGY={{ session_strategy }}
 BACKEND_PORT=8000
 FRONTEND_PORT=3000
 
+{% if 'github' in saas_connectors %}
+# GitHub (repository data import)
+GITHUB_TOKEN=your-github-pat-here  # Settings > Developer settings > Personal access tokens
+GITHUB_REPO=owner/repo  # e.g. neo4j-labs/create-context-graph
+{% endif %}
+{% if 'notion' in saas_connectors %}
+# Notion (knowledge base import)
+NOTION_TOKEN=your-notion-integration-token-here
+{% endif %}
+{% if 'jira' in saas_connectors %}
+# Jira (issue tracking import)
+JIRA_URL=https://your-org.atlassian.net
+JIRA_EMAIL=your-email@example.com
+JIRA_TOKEN=your-jira-api-token-here
+JIRA_PROJECT=your-project-key  # e.g. ENG
+{% endif %}
+{% if 'slack' in saas_connectors %}
+# Slack (channel history import)
+SLACK_TOKEN=your-slack-bot-token-here  # xoxb-...
+{% endif %}
+{% if 'salesforce' in saas_connectors %}
+# Salesforce (CRM data import)
+SALESFORCE_USERNAME=your-username@example.com
+SALESFORCE_PASSWORD=your-password-here
+SALESFORCE_SECURITY_TOKEN=your-security-token-here
+{% endif %}
 {% if 'linear' in saas_connectors %}
-# Linear (project management data import)
+# Linear (project management import)
 LINEAR_API_KEY=your-linear-api-key-here  # From Linear Settings > Security & Access > API
 LINEAR_TEAM=  # Optional: team key to filter import (e.g., ENG)
 {% endif %}

--- a/src/create_context_graph/templates/base/dot_env_example.j2
+++ b/src/create_context_graph/templates/base/dot_env_example.j2
@@ -25,7 +25,11 @@ FRONTEND_PORT=3000
 {% if 'github' in saas_connectors %}
 # GitHub (repository data import)
 GITHUB_TOKEN=your-github-pat-here  # Settings > Developer settings > Personal access tokens
-GITHUB_REPO=owner/repo  # e.g. neo4j-labs/create-context-graph
+GITHUB_REPO=owner/repo             # e.g. neo4j-labs/create-context-graph
+GITHUB_LIMIT=20                    # Default max for issues, PRs, and commits
+# GITHUB_ISSUES_LIMIT=20           # Override GITHUB_LIMIT for issues only
+# GITHUB_PRS_LIMIT=20              # Override GITHUB_LIMIT for pull requests only
+# GITHUB_COMMITS_LIMIT=20          # Override GITHUB_LIMIT for commits only
 {% endif %}
 {% if 'notion' in saas_connectors %}
 # Notion (knowledge base import)

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -254,6 +254,185 @@ class TestGitHubConnector:
 
         assert len(result.documents) == 1
 
+    def test_extract_refs_separates_closes_from_references(self):
+        from create_context_graph.connectors.github_connector import _extract_refs
+
+        closes, refs = _extract_refs("This fixes #1 and closes #2. See also #3 and #4.")
+        assert closes == {1, 2}
+        assert refs == {3, 4}
+
+    def test_extract_refs_overlapping_number(self):
+        from create_context_graph.connectors.github_connector import _extract_refs
+
+        # #5 appears with a closing keyword AND bare — must not be in references
+        closes, refs = _extract_refs("resolves #5. See prior discussion in #5.")
+        assert closes == {5}
+        assert refs == set()
+
+    def test_extract_refs_empty_text(self):
+        from create_context_graph.connectors.github_connector import _extract_refs
+
+        assert _extract_refs("") == (set(), set())
+        assert _extract_refs(None) == (set(), set())
+
+    def test_extract_refs_ignores_in_word_hashes(self):
+        from create_context_graph.connectors.github_connector import _extract_refs
+
+        # "abc#1" should not match (# inside a word)
+        closes, refs = _extract_refs("color abc#1 but see #7")
+        assert closes == set()
+        assert refs == {7}
+
+    def _make_mock_repo_with_linking_fixtures(self, mock_github_module):
+        """Repo with 1 Issue (#1), 1 PR (#10) whose body 'fixes #1', and 1 Commit referencing #10."""
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.description = "Test repo"
+        mock_repo.html_url = "https://github.com/owner/repo"
+        mock_repo.language = "Python"
+        mock_repo.stargazers_count = 0
+        mock_repo.organization = None
+
+        mock_user = MagicMock()
+        mock_user.login = "alice"
+        mock_user.name = "Alice"
+        mock_user.email = ""
+
+        mock_issue = MagicMock()
+        mock_issue.pull_request = None
+        mock_issue.number = 1
+        mock_issue.title = "Bug: things broken"
+        mock_issue.state = "open"
+        mock_issue.body = "something is broken"
+        mock_issue.created_at = None
+        mock_issue.labels = []
+        mock_issue.user = mock_user
+        mock_repo.get_issues.return_value = [mock_issue]
+
+        mock_pr = MagicMock()
+        mock_pr.number = 10
+        mock_pr.title = "Fix the thing"
+        mock_pr.state = "closed"
+        mock_pr.merged = True
+        mock_pr.body = "This fixes #1. See also #99 which does not exist in our fetched set."
+        mock_pr.created_at = None
+        mock_pr.user = mock_user
+        mock_repo.get_pulls.return_value = [mock_pr]
+
+        mock_commit = MagicMock()
+        mock_commit.sha = "abcdef1234567890"
+        mock_commit.commit.message = "Refactor. See #10 for rationale."
+        mock_commit.commit.author.date = None
+        mock_commit.author = mock_user
+        mock_repo.get_commits.return_value = [mock_commit]
+
+        mock_client = MagicMock()
+        mock_client.get_repo.return_value = mock_repo
+        mock_github_module.Github.return_value = mock_client
+        return mock_repo
+
+    def _fetch_with_linking(self, monkeypatch, **fetch_kwargs):
+        mock_github_module = MagicMock()
+        self._make_mock_repo_with_linking_fixtures(mock_github_module)
+        # Default link source to "regex" in tests so we don't hit the network
+        monkeypatch.setenv("GITHUB_LINK_SOURCE", "regex")
+        with patch.dict("sys.modules", {"github": mock_github_module}):
+            from create_context_graph.connectors.github_connector import GitHubConnector
+
+            conn = GitHubConnector()
+            conn.authenticate({"token": "fake", "repo": "owner/repo"})
+            return conn.fetch(**fetch_kwargs)
+
+    def test_linking_emits_closes_from_pr_body(self, monkeypatch):
+        result = self._fetch_with_linking(monkeypatch)
+        closes_rels = [r for r in result.relationships if r["type"] == "CLOSES"]
+        assert len(closes_rels) == 1
+        rel = closes_rels[0]
+        assert rel["source_name"] == "Fix the thing"
+        assert rel["source_label"] == "PullRequest"
+        assert rel["target_name"] == "Bug: things broken"
+        assert rel["target_label"] == "Issue"
+
+    def test_linking_emits_references_from_commit_message(self, monkeypatch):
+        result = self._fetch_with_linking(monkeypatch)
+        ref_rels = [r for r in result.relationships if r["type"] == "REFERENCES"]
+        commit_to_pr = [r for r in ref_rels if r["source_label"] == "Commit" and r["target_label"] == "PullRequest"]
+        assert len(commit_to_pr) == 1
+        assert commit_to_pr[0]["target_name"] == "Fix the thing"
+
+    def test_linking_skips_unknown_numbers(self, monkeypatch):
+        """#99 is referenced but not in the fetched set, so no relationship is emitted."""
+        result = self._fetch_with_linking(monkeypatch)
+        ref_rels = [r for r in result.relationships if r["type"] == "REFERENCES"]
+        # Only the Commit→PullRequest (#10) reference; nothing for #99
+        assert all(r["target_label"] in ("PullRequest", "Issue") for r in ref_rels)
+        assert not any(r["target_name"] == "99" for r in ref_rels)
+
+    def test_linking_disabled_by_kwarg(self, monkeypatch):
+        result = self._fetch_with_linking(monkeypatch, link_issues_prs=False)
+        link_types = {r["type"] for r in result.relationships}
+        assert "CLOSES" not in link_types
+        assert "REFERENCES" not in link_types
+
+    def test_linking_disabled_by_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_LINK_ISSUES_PRS", "false")
+        result = self._fetch_with_linking(monkeypatch)
+        link_types = {r["type"] for r in result.relationships}
+        assert "CLOSES" not in link_types
+        assert "REFERENCES" not in link_types
+
+    def test_linking_closes_takes_precedence_over_references(self, monkeypatch):
+        """A pair that matches both CLOSES and REFERENCES should only appear as CLOSES."""
+        result = self._fetch_with_linking(monkeypatch)
+        pairs_closes = {(r["source_name"], r["target_name"]) for r in result.relationships if r["type"] == "CLOSES"}
+        pairs_refs = {(r["source_name"], r["target_name"]) for r in result.relationships if r["type"] == "REFERENCES"}
+        assert pairs_closes & pairs_refs == set()
+
+    def test_linking_graphql_path_calls_fetcher(self, monkeypatch):
+        """With link_source=graphql, the regex path is skipped and GraphQL is consulted."""
+        mock_github_module = MagicMock()
+        self._make_mock_repo_with_linking_fixtures(mock_github_module)
+
+        call_log: list[int] = []
+
+        def fake_graphql(token, owner, repo_name, pr_number, timeout=30.0):
+            call_log.append(pr_number)
+            # Pretend the GraphQL API reports PR #10 closes issue #1
+            return [1] if pr_number == 10 else []
+
+        with patch.dict("sys.modules", {"github": mock_github_module}):
+            from create_context_graph.connectors import github_connector as gh_module
+            monkeypatch.setattr(gh_module, "_fetch_closing_refs_graphql", fake_graphql)
+
+            conn = gh_module.GitHubConnector()
+            conn.authenticate({"token": "fake", "repo": "owner/repo"})
+            result = conn.fetch(link_source="graphql")
+
+        assert call_log == [10]
+        closes_rels = [r for r in result.relationships if r["type"] == "CLOSES"]
+        assert len(closes_rels) == 1
+        assert closes_rels[0]["source_name"] == "Fix the thing"
+        assert closes_rels[0]["target_name"] == "Bug: things broken"
+
+    def test_linking_both_dedupes_across_sources(self, monkeypatch):
+        """regex + graphql reporting the same closure should produce only one CLOSES relationship."""
+        mock_github_module = MagicMock()
+        self._make_mock_repo_with_linking_fixtures(mock_github_module)
+
+        def fake_graphql(token, owner, repo_name, pr_number, timeout=30.0):
+            return [1] if pr_number == 10 else []
+
+        with patch.dict("sys.modules", {"github": mock_github_module}):
+            from create_context_graph.connectors import github_connector as gh_module
+            monkeypatch.setattr(gh_module, "_fetch_closing_refs_graphql", fake_graphql)
+
+            conn = gh_module.GitHubConnector()
+            conn.authenticate({"token": "fake", "repo": "owner/repo"})
+            result = conn.fetch(link_source="both")
+
+        closes_rels = [r for r in result.relationships if r["type"] == "CLOSES" and r["target_name"] == "Bug: things broken"]
+        assert len(closes_rels) == 1
+
 
 class TestNotionConnector:
     def test_fetch_returns_normalized_data(self):

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -165,6 +165,95 @@ class TestGitHubConnector:
         assert "Repository" in result.entities
         assert len(result.entities["Repository"]) == 1
 
+    def _make_mock_repo_with_issue(self, mock_github_module):
+        """Helper that returns a mock repo with one issue that has a body."""
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.description = "Test repo"
+        mock_repo.html_url = "https://github.com/owner/repo"
+        mock_repo.language = "Python"
+        mock_repo.stargazers_count = 0
+        mock_repo.organization = None
+        mock_repo.get_pulls.return_value = []
+        mock_repo.get_commits.return_value = []
+
+        mock_user = MagicMock()
+        mock_user.login = "alice"
+        mock_user.name = "Alice"
+        mock_user.email = ""
+
+        mock_issue = MagicMock()
+        mock_issue.pull_request = None
+        mock_issue.number = 1
+        mock_issue.title = "Test issue"
+        mock_issue.state = "open"
+        mock_issue.body = "Issue body content"
+        mock_issue.created_at = None
+        mock_issue.labels = []
+        mock_issue.user = mock_user
+
+        mock_repo.get_issues.return_value = [mock_issue]
+
+        mock_client = MagicMock()
+        mock_client.get_repo.return_value = mock_repo
+        mock_github_module.Github.return_value = mock_client
+        return mock_repo
+
+    def test_import_body_default_true(self):
+        mock_github_module = MagicMock()
+        self._make_mock_repo_with_issue(mock_github_module)
+
+        with patch.dict("sys.modules", {"github": mock_github_module}):
+            from create_context_graph.connectors.github_connector import GitHubConnector
+
+            conn = GitHubConnector()
+            conn.authenticate({"token": "fake", "repo": "owner/repo"})
+            result = conn.fetch()
+
+        assert len(result.documents) == 1
+        assert result.documents[0]["type"] == "issue-body"
+
+    def test_import_body_kwarg_false(self):
+        mock_github_module = MagicMock()
+        self._make_mock_repo_with_issue(mock_github_module)
+
+        with patch.dict("sys.modules", {"github": mock_github_module}):
+            from create_context_graph.connectors.github_connector import GitHubConnector
+
+            conn = GitHubConnector()
+            conn.authenticate({"token": "fake", "repo": "owner/repo"})
+            result = conn.fetch(import_body=False)
+
+        assert result.documents == []
+
+    def test_import_body_env_false(self, monkeypatch):
+        mock_github_module = MagicMock()
+        self._make_mock_repo_with_issue(mock_github_module)
+        monkeypatch.setenv("GITHUB_IMPORT_BODY", "false")
+
+        with patch.dict("sys.modules", {"github": mock_github_module}):
+            from create_context_graph.connectors.github_connector import GitHubConnector
+
+            conn = GitHubConnector()
+            conn.authenticate({"token": "fake", "repo": "owner/repo"})
+            result = conn.fetch()
+
+        assert result.documents == []
+
+    def test_import_body_kwarg_overrides_env(self, monkeypatch):
+        mock_github_module = MagicMock()
+        self._make_mock_repo_with_issue(mock_github_module)
+        monkeypatch.setenv("GITHUB_IMPORT_BODY", "false")
+
+        with patch.dict("sys.modules", {"github": mock_github_module}):
+            from create_context_graph.connectors.github_connector import GitHubConnector
+
+            conn = GitHubConnector()
+            conn.authenticate({"token": "fake", "repo": "owner/repo"})
+            result = conn.fetch(import_body=True)
+
+        assert len(result.documents) == 1
+
 
 class TestNotionConnector:
     def test_fetch_returns_normalized_data(self):

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -542,6 +542,60 @@ class TestProjectRenderer:
         prompts = [p for s in ctx["demo_scenarios"] for p in s["prompts"]]
         assert not any("pull request" in p.lower() for p in prompts)
 
+    def test_config_py_has_connector_fields(self, tmp_output):
+        """Verify config.py includes Settings fields for each selected connector."""
+        cases = [
+            ("github", ["github_token", "github_repo"]),
+            ("notion", ["notion_token"]),
+            ("jira", ["jira_url", "jira_email", "jira_token", "jira_project"]),
+            ("slack", ["slack_token", "slack_channels"]),
+            ("salesforce", ["salesforce_username", "salesforce_password"]),
+            ("linear", ["linear_api_key", "linear_team"]),
+            ("claude-code", ["claude_code_scope", "claude_code_since"]),
+        ]
+        for connector_id, expected_fields in cases:
+            config = ProjectConfig(
+                project_name="test-config",
+                domain="software-engineering",
+                framework="pydanticai",
+                saas_connectors=[connector_id],
+            )
+            ontology = load_domain(config.domain)
+            renderer = ProjectRenderer(config, ontology)
+            renderer.render(tmp_output)
+            config_py = (tmp_output / "backend" / "app" / "config.py").read_text()
+            for field in expected_fields:
+                assert field in config_py, (
+                    f"config.py missing '{field}' when connector '{connector_id}' is selected"
+                )
+
+    def test_pyproject_has_connector_deps(self, tmp_output):
+        """Verify pyproject.toml includes the right package for each connector."""
+        cases = [
+            ("github", "PyGithub"),
+            ("notion", "notion-client"),
+            ("jira", "atlassian-python-api"),
+            ("slack", "slack-sdk"),
+            ("salesforce", "simple-salesforce"),
+            ("gmail", "google-api-python-client"),
+            ("gcal", "google-api-python-client"),
+            ("google-workspace", "google-api-python-client"),
+        ]
+        for connector_id, expected_pkg in cases:
+            config = ProjectConfig(
+                project_name="test-deps",
+                domain="software-engineering",
+                framework="pydanticai",
+                saas_connectors=[connector_id],
+            )
+            ontology = load_domain(config.domain)
+            renderer = ProjectRenderer(config, ontology)
+            renderer.render(tmp_output)
+            pyproject = (tmp_output / "backend" / "pyproject.toml").read_text()
+            assert expected_pkg in pyproject, (
+                f"pyproject.toml missing '{expected_pkg}' when connector '{connector_id}' is selected"
+            )
+
     def test_no_scenario_override_without_connector(self, financial_config, tmp_output):
         """Without claude-code connector, domain scenarios should be used as-is."""
         ontology = load_domain(financial_config.domain)


### PR DESCRIPTION
### Fixes to get GitHub Connector working well

  ```
  ┌──────────────────────────────┬──────────────────────────────────────────────────────────────┐
  │            File              │                           Fix                                │
 ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ config.py.j2                 │ Added Settings fields for all 7 connectors (github, notion,  │
  │                              │ jira, slack, salesforce, linear, etc.)                       │
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ pyproject.toml.j2            │ Added connector package deps (PyGithub, notion-client, etc.) │
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ github_connector.py + .j2    │ source→source_name, target→target_name; islice for pagination│
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ All other connectors +       │ source→source_name, target→target_name in relationship dicts │
│   templates                  │                                                              │
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ memory.py.j2                 │ | tojson → | capitalize so True/False not true/false         │
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ Makefile.j2                  │ Added make schema target; clarified make seed and            │
  │                              │ make import-and-seed comments                                │
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ dot_env.j2 + dot_env_        │ Added all connector credential env vars and GITHUB_LIMIT     │
  │   example.j2                 │ block (commented overrides for issues/PRs/commits)           │
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ test_routes.py.j2            │ Mock is_connected via app.main (not app.context_graph_client)│
  │                              │ setdefault API keys before import to satisfy PydanticAI      │
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ cli.py                       │ Aligned connector option commands and comments in CLI output │
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ github_connector.py + .j2    │ Per-resource limits: GITHUB_LIMIT (default 20) with          │
  │ config.py.j2, dot_env*.j2    │ GITHUB_ISSUES/PRS/COMMITS_LIMIT overrides; import_data.py.j2 │
  │ import_data.py.j2            │ passes limits through                                        │
  ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
  │ github_connector.py + .j2    │ Renamed Document→Body for issues/PRs (type: issue-body /     │
  │                              │ pr-body); added GITHUB_IMPORT_BODY toggle (default true)     │
  └──────────────────────────────┴──────────────────────────────────────────────────────────────┘
  ```
  
  ### Also add linking of GH Commits, Issues, PRs
  
  ```
  New env vars / kwargs:
  - GITHUB_LINK_ISSUES_PRS=true — default on; set false/0/no to disable
  - GITHUB_LINK_SOURCE=both — regex | graphql | both (falls back to both on invalid values)

  Behavior:
  - Regex scans issue bodies, PR bodies, and full commit messages for (close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) #N → CLOSES; bare #N → REFERENCES
  - GraphQL (closingIssuesReferences) queries per PR for authoritative closures
  - CLOSES takes precedence over REFERENCES on the same pair, and regex+GraphQL are deduped
  - References to numbers outside the fetched set (e.g., #99 when you only pulled 20 items) are silently skipped
  - GraphQL failures log a warning and return empty — no hard failure

  Files touched:
  - connectors/github_connector.py + .j2 template
  - dot_env.j2, dot_env_example.j2, config.py.j2, import_data.py.j2
  - tests/test_connectors.py — 12 new tests
  ```