### PR TITLE
Ensure proper connection handling in reset_database function

### DIFF
--- a/src/create_context_graph/templates/backend/shared/context_graph_client.py.j2
+++ b/src/create_context_graph/templates/backend/shared/context_graph_client.py.j2
@@ -375,10 +375,13 @@ async def expand_node(element_id: str) -> dict:
 
 
 async def reset_database() -> None:
-    """Drop all data and recreate schema."""
-    await connect_neo4j()
+    """Drop all data. Opens a connection if not already connected; preserves an existing connection."""
+    was_connected = _driver is not None
+    if not was_connected:
+        await connect_neo4j()
     try:
         await execute_cypher("MATCH (n) DETACH DELETE n", collect=False)
     finally:
-        await close_neo4j()
+        if not was_connected:
+            await close_neo4j()
 {% endraw %}

--- a/src/create_context_graph/templates/backend/shared/context_graph_client.py.j2
+++ b/src/create_context_graph/templates/backend/shared/context_graph_client.py.j2
@@ -376,5 +376,9 @@ async def expand_node(element_id: str) -> dict:
 
 async def reset_database() -> None:
     """Drop all data and recreate schema."""
-    await execute_cypher("MATCH (n) DETACH DELETE n", collect=False)
+    await connect_neo4j()
+    try:
+        await execute_cypher("MATCH (n) DETACH DELETE n", collect=False)
+    finally:
+        await close_neo4j()
 {% endraw %}

--- a/tests/test_generated_project.py
+++ b/tests/test_generated_project.py
@@ -1055,6 +1055,38 @@ class TestCollectorThreadSafety:
         assert "_loop" in client_py
 
 
+class TestResetDatabase:
+    """Verify reset_database() handles connection lifecycle correctly (fix for #26)."""
+
+    def test_reset_database_connects_when_not_connected(self, generated_project):
+        """reset_database must open its own connection when _driver is None."""
+        out, _ = generated_project
+        client = (out / "backend" / "app" / "context_graph_client.py").read_text()
+        assert "was_connected = _driver is not None" in client
+        assert "await connect_neo4j()" in client
+
+    def test_reset_database_closes_connection_it_opened(self, generated_project):
+        """reset_database must close a connection it opened (try/finally pattern)."""
+        out, _ = generated_project
+        client = (out / "backend" / "app" / "context_graph_client.py").read_text()
+        assert "try:" in client
+        assert "finally:" in client
+        assert "await close_neo4j()" in client
+
+    def test_reset_database_preserves_existing_connection(self, generated_project):
+        """reset_database must NOT close a pre-existing connection."""
+        out, _ = generated_project
+        client = (out / "backend" / "app" / "context_graph_client.py").read_text()
+        # The guard ensures close_neo4j is only called when was_connected is False
+        assert "if not was_connected:" in client
+
+    def test_reset_database_uses_detach_delete(self, generated_project):
+        """reset_database must use DETACH DELETE to clear all nodes and relationships."""
+        out, _ = generated_project
+        client = (out / "backend" / "app" / "context_graph_client.py").read_text()
+        assert "MATCH (n) DETACH DELETE n" in client
+
+
 class TestToolPromptSuffix:
     """Verify all agent frameworks include tool-use emphasis in system prompt."""
 


### PR DESCRIPTION
## Problem

`make reset` fails with:

RuntimeError: Neo4j not connected. Call connect_neo4j() first.

`reset_database()` in the generated `context_graph_client.py` called
`execute_cypher()` directly without initializing the driver first.

## Fix

Wrap the DELETE query with `connect_neo4j()` / `close_neo4j()` in a
`try/finally` block — same pattern used elsewhere in the codebase.

## Change

`templates/backend/shared/context_graph_client.py.j2` — 4-line change
in `reset_database()`.

Fixes #26