### PR TITLE
Fix --custom-domain crash, langgraph stub regression, and LLM truncation

### DIFF
--- a/src/create_context_graph/cli.py
+++ b/src/create_context_graph/cli.py
@@ -154,7 +154,7 @@ def _run_import_preview(
 @click.option("--anthropic-api-key", envvar="ANTHROPIC_API_KEY", help="Anthropic API key for LLM generation")
 @click.option("--openai-api-key", envvar="OPENAI_API_KEY", help="OpenAI API key for LLM generation")
 @click.option("--google-api-key", envvar="GOOGLE_API_KEY", help="Google/Gemini API key (required for google-adk framework)")
-@click.option("--custom-domain", type=str, help="Natural language description for custom domain generation (requires --anthropic-api-key)")
+@click.option("--custom-domain", type=str, help="Natural language description for custom domain generation. Requires --anthropic-api-key AND the 'anthropic' SDK; if running via uvx, use 'uvx --with anthropic create-context-graph ...'")
 @click.option("--connector", multiple=True, help="SaaS connector to enable (github, slack, jira, notion, gmail, gcal, salesforce, linear, google-workspace, claude-code, claude-ai, chatgpt, local-file)")
 @click.option("--linear-api-key", envvar="LINEAR_API_KEY", help="Linear API key (required for --connector linear)")
 @click.option("--linear-team", envvar="LINEAR_TEAM", help="Linear team key to filter import (e.g., ENG)")

--- a/src/create_context_graph/custom_domain.py
+++ b/src/create_context_graph/custom_domain.py
@@ -38,6 +38,45 @@ from create_context_graph.ontology import (
 
 console = Console()
 
+# Output budget for ontology generation. Real domain YAMLs run 15–25 KB
+# (roughly 5–8k tokens of YAML text), so the generator-wide 4096 default
+# truncated full ontologies — leaving system_prompt / visualization /
+# agent_tools missing while still parsing as valid (default-empty) YAML.
+_ONTOLOGY_MAX_TOKENS = 16384
+
+
+class _TruncatedOntologyError(ValueError):
+    """Raised when the LLM hits the max_tokens cap before finishing the YAML."""
+
+
+class _IncompleteOntologyError(ValueError):
+    """Raised when a parsed ontology is missing required sections."""
+
+
+def _validate_ontology_completeness(ontology: DomainOntology) -> list[str]:
+    """Return a list of human-readable problems with a parsed ontology.
+
+    The Pydantic schema accepts default-empty values for every optional
+    section, so a truncated YAML happily round-trips into a "valid" but
+    skeletal ontology. Use this check after schema validation to ensure
+    the LLM actually generated a usable scaffold.
+    """
+    problems: list[str] = []
+    if not ontology.system_prompt or not ontology.system_prompt.strip():
+        problems.append("system_prompt is missing or empty")
+    if not ontology.visualization.node_colors:
+        problems.append("visualization.node_colors is empty")
+    if len(ontology.agent_tools) < 3:
+        problems.append(
+            f"agent_tools must have at least 3 entries (got {len(ontology.agent_tools)})"
+        )
+    if len(ontology.entity_types) < 3:
+        problems.append(
+            f"entity_types must have at least 3 domain-specific entries "
+            f"(got {len(ontology.entity_types)})"
+        )
+    return problems
+
 
 # ---------------------------------------------------------------------------
 # Prompt construction
@@ -220,7 +259,13 @@ def generate_custom_domain(
     client, resolved_provider = _get_llm_client(api_key, provider)
     if client is None:
         raise ValueError(
-            "Could not initialize LLM client. Install 'anthropic' or 'openai' package."
+            "Could not initialize LLM client — the 'anthropic' or 'openai' "
+            "package is not installed.\n"
+            "  • pip install:  pip install 'create-context-graph[generate]'\n"
+            "  • uvx invocation: uvx --with anthropic create-context-graph "
+            "--custom-domain '...' --anthropic-api-key sk-ant-...\n"
+            "  • or: uvx --with openai create-context-graph --custom-domain "
+            "'...' --openai-api-key sk-..."
         )
 
     base_yaml, examples = _load_example_yamls()
@@ -232,27 +277,69 @@ def generate_custom_domain(
         "syntactically valid YAML that passes strict Pydantic validation."
     )
 
-    last_error = None
+    last_error: Exception | None = None
     raw_yaml = ""
 
     for attempt in range(max_retries):
         if attempt == 0:
-            raw_yaml = _llm_generate(client, resolved_provider, prompt, system)
+            call_prompt = prompt
         else:
-            retry_prompt = _build_retry_prompt(description, raw_yaml, str(last_error))
-            raw_yaml = _llm_generate(client, resolved_provider, retry_prompt, system)
+            call_prompt = _build_retry_prompt(description, raw_yaml, str(last_error))
 
+        raw_yaml, stop_reason = _llm_generate(
+            client,
+            resolved_provider,
+            call_prompt,
+            system,
+            max_tokens=_ONTOLOGY_MAX_TOKENS,
+            return_stop_reason=True,
+        )
         raw_yaml = _strip_yaml_fences(raw_yaml)
 
+        # Step 1: detect cap-truncation before even trying to parse — the
+        # tail of a truncated YAML is often a half-formed key that breaks
+        # the parser, but sometimes parses to a no-op default. Either way
+        # the output isn't usable.
+        truncated = stop_reason in ("max_tokens", "length")
+        if truncated:
+            last_error = _TruncatedOntologyError(
+                f"LLM hit max_tokens={_ONTOLOGY_MAX_TOKENS} (stop_reason={stop_reason}); "
+                "the YAML is incomplete. Asking the LLM to be more concise on retry."
+            )
+            if attempt < max_retries - 1:
+                console.print(
+                    f"[yellow]Truncated output (attempt {attempt + 1}/{max_retries}), retrying...[/yellow]"
+                )
+            continue
+
+        # Step 2: schema-validate (catches malformed YAML and Pydantic errors)
         try:
             ontology = load_domain_from_yaml_string(raw_yaml)
-            return ontology, raw_yaml
         except (ValidationError, ValueError, yaml.YAMLError) as e:
             last_error = e
             if attempt < max_retries - 1:
                 console.print(
                     f"[yellow]Validation failed (attempt {attempt + 1}/{max_retries}), retrying...[/yellow]"
                 )
+            continue
+
+        # Step 3: completeness check (catches truncations that still parse —
+        # DomainOntology has default-empty fields, so a YAML missing
+        # system_prompt / visualization / agent_tools round-trips silently).
+        problems = _validate_ontology_completeness(ontology)
+        if problems:
+            last_error = _IncompleteOntologyError(
+                "Generated ontology is missing required sections: "
+                + "; ".join(problems)
+            )
+            if attempt < max_retries - 1:
+                console.print(
+                    f"[yellow]Incomplete ontology (attempt {attempt + 1}/{max_retries}): "
+                    f"{', '.join(problems)} — retrying...[/yellow]"
+                )
+            continue
+
+        return ontology, raw_yaml
 
     raise ValueError(
         f"Failed to generate valid domain after {max_retries} attempts. "

--- a/src/create_context_graph/generator.py
+++ b/src/create_context_graph/generator.py
@@ -61,16 +61,35 @@ def _get_llm_client(api_key: str, provider: str = "anthropic"):
     return None, None
 
 
-def _llm_generate(client, provider: str, prompt: str, system: str = "") -> str:
-    """Generate text using the LLM client."""
+def _llm_generate(
+    client,
+    provider: str,
+    prompt: str,
+    system: str = "",
+    *,
+    max_tokens: int = 4096,
+    return_stop_reason: bool = False,
+):
+    """Generate text using the LLM client.
+
+    By default returns just the text (back-compat). Pass
+    ``return_stop_reason=True`` to receive ``(text, stop_reason)`` — useful
+    for callers that need to detect truncation (``"max_tokens"`` for
+    Anthropic, ``"length"`` for OpenAI). Pass ``max_tokens`` higher than the
+    4096 default when generating long outputs such as full ontology YAMLs.
+    """
+    text = ""
+    stop_reason: str | None = None
+
     if provider == "anthropic":
         response = client.messages.create(
             model="claude-sonnet-4-20250514",
-            max_tokens=4096,
+            max_tokens=max_tokens,
             system=system,
             messages=[{"role": "user", "content": prompt}],
         )
-        return response.content[0].text
+        text = response.content[0].text
+        stop_reason = getattr(response, "stop_reason", None)
     elif provider == "openai":
         messages = []
         if system:
@@ -79,10 +98,15 @@ def _llm_generate(client, provider: str, prompt: str, system: str = "") -> str:
         response = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=messages,
-            max_tokens=4096,
+            max_tokens=max_tokens,
         )
-        return response.choices[0].message.content
-    return ""
+        choice = response.choices[0]
+        text = choice.message.content or ""
+        stop_reason = getattr(choice, "finish_reason", None)
+
+    if return_stop_reason:
+        return text, stop_reason
+    return text
 
 
 def _llm_generate_json(client, provider: str, prompt: str, system: str = "") -> Any:

--- a/src/create_context_graph/renderer.py
+++ b/src/create_context_graph/renderer.py
@@ -27,6 +27,7 @@ from jinja2.exceptions import TemplateNotFound
 from create_context_graph.config import ProjectConfig
 from create_context_graph.ontology import (
     DomainOntology,
+    _get_domains_path,
     generate_cypher_schema,
     generate_pydantic_models,
     generate_visualization_config,
@@ -554,13 +555,11 @@ class ProjectRenderer:
             # Write custom domain YAML directly
             (data_dir / "ontology.yaml").write_text(self.config.custom_domain_yaml)
         else:
-            from create_context_graph.ontology import _get_domains_path
-
             domain_yaml = _get_domains_path() / f"{self.config.domain}.yaml"
             if domain_yaml.exists():
                 shutil.copy2(domain_yaml, data_dir / "ontology.yaml")
 
-        # Also copy base
+        # Also copy base (always — independent of custom-vs-builtin domain)
         base_yaml = _get_domains_path() / "_base.yaml"
         if base_yaml.exists():
             shutil.copy2(base_yaml, data_dir / "_base.yaml")

--- a/src/create_context_graph/renderer.py
+++ b/src/create_context_graph/renderer.py
@@ -22,6 +22,7 @@ from importlib.resources import files
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader
+from jinja2.exceptions import TemplateNotFound
 
 from create_context_graph.config import ProjectConfig
 from create_context_graph.ontology import (
@@ -425,13 +426,27 @@ class ProjectRenderer:
         (backend_dir / "app").mkdir(parents=True, exist_ok=True)
         (backend_dir / "app" / "__init__.py").write_text("")
 
-        # Framework-specific agent template
+        # Framework-specific agent template. Only fall back to the stub when
+        # the framework directory doesn't exist (e.g. a new framework key was
+        # added without a template). Template-rendering errors — Jinja syntax,
+        # undefined variables, missing context — must propagate so they don't
+        # silently degrade into a 36-line stub the way the v0.11.0 langgraph
+        # regression did.
         fw_key = self.config.resolved_framework.replace("-", "_")
         agent_template = f"backend/agents/{fw_key}/agent.py.j2"
         try:
             self._render_template(agent_template, backend_dir / "app" / "agent.py", ctx)
-        except Exception:
-            # Fallback: render a minimal agent stub
+        except TemplateNotFound:
+            # Genuine missing template — render the documented stub so the
+            # scaffold still boots, but make the situation discoverable.
+            import warnings
+
+            warnings.warn(
+                f"No agent template found at {agent_template}; "
+                "falling back to the placeholder stub. The scaffolded "
+                "backend/app/agent.py will need a real implementation.",
+                stacklevel=2,
+            )
             self._render_template(
                 "backend/shared/agent_stub.py.j2",
                 backend_dir / "app" / "agent.py",

--- a/src/create_context_graph/templates/backend/agents/anthropic_tools/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/anthropic_tools/agent.py.j2
@@ -53,7 +53,7 @@ def register_tool(name: str, description: str):
 
 {% for tool in agent_tools %}
 @register_tool("{{ tool.name }}", "{{ tool.description }}")
-async def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
+async def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is defined and param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
     """{{ tool.description }}"""
     cypher = """{{ tool.cypher | indent(4) }}"""
     params = {

--- a/src/create_context_graph/templates/backend/agents/claude_agent_sdk/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/claude_agent_sdk/agent.py.j2
@@ -39,7 +39,7 @@ TOOLS = [
                 },
 {% endfor %}
             },
-            "required": [{% for param in tool.parameters %}{% if param.default is none %}"{{ param.name }}"{% if not loop.last %}, {% endif %}{% endif %}{% endfor %}],
+            "required": [{% for param in tool.parameters %}{% if (param.default is not defined or param.default is none) %}"{{ param.name }}"{% if not loop.last %}, {% endif %}{% endif %}{% endfor %}],
         },
     },
 {% endfor %}

--- a/src/create_context_graph/templates/backend/agents/crewai/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/crewai/agent.py.j2
@@ -65,7 +65,7 @@ CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll se
 
 {% for tool in agent_tools %}
 @tool
-def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
+def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is defined and param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
     """{{ tool.description }}"""
     cypher = """{{ tool.cypher | indent(4) }}"""
     params = {

--- a/src/create_context_graph/templates/backend/agents/google_adk/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/google_adk/agent.py.j2
@@ -63,7 +63,7 @@ CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll se
 # ---------------------------------------------------------------------------
 
 {% for tool in agent_tools %}
-def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
+def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is defined and param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
     """{{ tool.description }}"""
     cypher = """{{ tool.cypher | indent(4) }}"""
     params = {

--- a/src/create_context_graph/templates/backend/agents/langgraph/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/langgraph/agent.py.j2
@@ -25,7 +25,7 @@ CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll se
 
 {% for tool in agent_tools %}
 @tool
-async def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
+async def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is defined and param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
     """{{ tool.description }}"""
     cypher = """{{ tool.cypher | indent(4) }}"""
     params = {

--- a/src/create_context_graph/templates/backend/agents/openai_agents/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/openai_agents/agent.py.j2
@@ -23,7 +23,7 @@ CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll se
 
 {% for tool in agent_tools %}
 @function_tool
-async def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
+async def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is defined and param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
     """{{ tool.description }}"""
     cypher = """{{ tool.cypher | indent(4) }}"""
     params = {

--- a/src/create_context_graph/templates/backend/agents/pydanticai/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/pydanticai/agent.py.j2
@@ -62,7 +62,7 @@ agent = Agent(
 
 {% for tool in agent_tools %}
 @agent.tool
-async def {{ tool.name }}(ctx: RunContext[AgentDeps]{% for param in tool.parameters %}, {{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% endfor %}) -> str:
+async def {{ tool.name }}(ctx: RunContext[AgentDeps]{% for param in tool.parameters %}, {{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is defined and param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% endfor %}) -> str:
     """{{ tool.description }}"""
     cypher = """{{ tool.cypher | indent(4) }}"""
     params = {

--- a/src/create_context_graph/templates/backend/agents/strands/agent.py.j2
+++ b/src/create_context_graph/templates/backend/agents/strands/agent.py.j2
@@ -62,7 +62,7 @@ CRITICAL: Call tools DIRECTLY without any introductory text. Do NOT say "I'll se
 
 {% for tool in agent_tools %}
 @tool
-def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
+def {{ tool.name }}({% for param in tool.parameters %}{{ param.name }}: {{ 'str' if param.type == 'string' else 'int' if param.type == 'integer' else 'float' if param.type == 'float' else 'str' }}{% if param.default is defined and param.default is not none %} = {{ param.default if param.type != 'string' else '"' + param.default + '"' }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> str:
     """{{ tool.description }}"""
     cypher = """{{ tool.cypher | indent(4) }}"""
     params = {

--- a/tests/test_custom_domain.py
+++ b/tests/test_custom_domain.py
@@ -20,9 +20,11 @@ import pytest
 from pydantic import ValidationError
 
 from create_context_graph.custom_domain import (
+    _ONTOLOGY_MAX_TOKENS,
     _build_domain_generation_prompt,
     _build_retry_prompt,
     _strip_yaml_fences,
+    _validate_ontology_completeness,
     display_ontology_summary,
     generate_custom_domain,
     save_custom_domain,
@@ -279,11 +281,15 @@ class TestStripYamlFences:
 
 
 class TestGenerateCustomDomain:
+    # generate_custom_domain now calls _llm_generate with return_stop_reason=True,
+    # so all mocks must return ``(text, stop_reason)``. ``stop_reason="end_turn"``
+    # is the normal-completion value for Anthropic (OpenAI's equivalent is
+    # ``"stop"``); ``"max_tokens"`` / ``"length"`` signal truncation.
     @patch("create_context_graph.custom_domain._llm_generate")
     @patch("create_context_graph.custom_domain._get_llm_client")
     def test_success(self, mock_get_client, mock_generate):
         mock_get_client.return_value = (MagicMock(), "anthropic")
-        mock_generate.return_value = VALID_DOMAIN_YAML
+        mock_generate.return_value = (VALID_DOMAIN_YAML, "end_turn")
 
         ontology, raw_yaml = generate_custom_domain("test domain", "fake-key")
         assert isinstance(ontology, DomainOntology)
@@ -295,7 +301,10 @@ class TestGenerateCustomDomain:
     def test_retry_on_validation_error(self, mock_get_client, mock_generate):
         mock_get_client.return_value = (MagicMock(), "anthropic")
         # First call returns invalid, second returns valid
-        mock_generate.side_effect = [INVALID_DOMAIN_YAML, VALID_DOMAIN_YAML]
+        mock_generate.side_effect = [
+            (INVALID_DOMAIN_YAML, "end_turn"),
+            (VALID_DOMAIN_YAML, "end_turn"),
+        ]
 
         ontology, raw_yaml = generate_custom_domain("test domain", "fake-key")
         assert isinstance(ontology, DomainOntology)
@@ -305,7 +314,7 @@ class TestGenerateCustomDomain:
     @patch("create_context_graph.custom_domain._get_llm_client")
     def test_max_retries_exceeded(self, mock_get_client, mock_generate):
         mock_get_client.return_value = (MagicMock(), "anthropic")
-        mock_generate.return_value = INVALID_DOMAIN_YAML
+        mock_generate.return_value = (INVALID_DOMAIN_YAML, "end_turn")
 
         with pytest.raises(ValueError, match="Failed to generate valid domain"):
             generate_custom_domain("test domain", "fake-key", max_retries=2)
@@ -314,6 +323,120 @@ class TestGenerateCustomDomain:
         with patch("create_context_graph.custom_domain._get_llm_client", return_value=(None, None)):
             with pytest.raises(ValueError, match="Could not initialize LLM client"):
                 generate_custom_domain("test", "fake")
+
+    def test_no_client_error_message_is_actionable(self):
+        """When anthropic/openai isn't installed (common uvx footgun), the
+        error must tell the user exactly how to fix it.
+        """
+        with patch(
+            "create_context_graph.custom_domain._get_llm_client",
+            return_value=(None, None),
+        ):
+            with pytest.raises(ValueError) as excinfo:
+                generate_custom_domain("test", "fake")
+        msg = str(excinfo.value)
+        # Must mention both the pip-install and uvx-invocation paths.
+        assert "pip install" in msg
+        assert "create-context-graph[generate]" in msg
+        assert "uvx --with anthropic" in msg
+
+    @patch("create_context_graph.custom_domain._llm_generate")
+    @patch("create_context_graph.custom_domain._get_llm_client")
+    def test_uses_large_max_tokens(self, mock_get_client, mock_generate):
+        """The generator-wide 4096 default truncated 20KB+ ontology YAMLs.
+        Custom-domain generation must request a large output budget.
+        """
+        mock_get_client.return_value = (MagicMock(), "anthropic")
+        mock_generate.return_value = (VALID_DOMAIN_YAML, "end_turn")
+
+        generate_custom_domain("test domain", "fake-key")
+        # Inspect what _llm_generate was actually called with.
+        call_kwargs = mock_generate.call_args.kwargs
+        assert call_kwargs["max_tokens"] >= 16000, (
+            f"max_tokens must be large enough for full ontologies "
+            f"(~5–8k tokens of YAML); got {call_kwargs['max_tokens']}"
+        )
+        assert call_kwargs["return_stop_reason"] is True
+
+    @patch("create_context_graph.custom_domain._llm_generate")
+    @patch("create_context_graph.custom_domain._get_llm_client")
+    def test_truncation_triggers_retry(self, mock_get_client, mock_generate):
+        """When the LLM hits max_tokens, the partial output must be retried."""
+        mock_get_client.return_value = (MagicMock(), "anthropic")
+        # First call: truncated (parses OK-ish but should be rejected by
+        # stop_reason check). Second call: complete.
+        mock_generate.side_effect = [
+            (VALID_DOMAIN_YAML, "max_tokens"),  # would otherwise succeed
+            (VALID_DOMAIN_YAML, "end_turn"),
+        ]
+        ontology, _ = generate_custom_domain("test", "fake-key")
+        assert isinstance(ontology, DomainOntology)
+        assert mock_generate.call_count == 2
+
+    @patch("create_context_graph.custom_domain._llm_generate")
+    @patch("create_context_graph.custom_domain._get_llm_client")
+    def test_persistent_truncation_raises(self, mock_get_client, mock_generate):
+        mock_get_client.return_value = (MagicMock(), "anthropic")
+        mock_generate.return_value = (VALID_DOMAIN_YAML, "max_tokens")
+        with pytest.raises(ValueError, match="Failed to generate valid domain"):
+            generate_custom_domain("test", "fake-key", max_retries=2)
+
+    @patch("create_context_graph.custom_domain._llm_generate")
+    @patch("create_context_graph.custom_domain._get_llm_client")
+    def test_incomplete_ontology_triggers_retry(self, mock_get_client, mock_generate):
+        """A YAML missing system_prompt parses successfully (Pydantic defaults
+        to empty) but is unusable — must be caught by the completeness check.
+        """
+        mock_get_client.return_value = (MagicMock(), "anthropic")
+        # Strip system_prompt and visualization sections — the YAML still parses
+        # but produces a skeletal ontology with empty defaults.
+        truncated_yaml = VALID_DOMAIN_YAML.split("system_prompt:")[0]
+        mock_generate.side_effect = [
+            (truncated_yaml, "end_turn"),  # parses, but incomplete
+            (VALID_DOMAIN_YAML, "end_turn"),
+        ]
+        ontology, _ = generate_custom_domain("test", "fake-key")
+        assert isinstance(ontology, DomainOntology)
+        assert ontology.system_prompt  # second attempt had it
+        assert mock_generate.call_count == 2
+
+
+class TestValidateOntologyCompleteness:
+    """Direct tests for _validate_ontology_completeness."""
+
+    def test_full_ontology_is_complete(self):
+        ontology = load_domain_from_yaml_string(VALID_DOMAIN_YAML)
+        assert _validate_ontology_completeness(ontology) == []
+
+    def test_missing_system_prompt_flagged(self):
+        ontology = load_domain_from_yaml_string(VALID_DOMAIN_YAML)
+        ontology.system_prompt = ""
+        problems = _validate_ontology_completeness(ontology)
+        assert any("system_prompt" in p for p in problems)
+
+    def test_empty_visualization_flagged(self):
+        ontology = load_domain_from_yaml_string(VALID_DOMAIN_YAML)
+        ontology.visualization.node_colors = {}
+        problems = _validate_ontology_completeness(ontology)
+        assert any("visualization.node_colors" in p for p in problems)
+
+    def test_too_few_agent_tools_flagged(self):
+        ontology = load_domain_from_yaml_string(VALID_DOMAIN_YAML)
+        ontology.agent_tools = ontology.agent_tools[:2]
+        problems = _validate_ontology_completeness(ontology)
+        assert any("agent_tools" in p for p in problems)
+
+    def test_too_few_entity_types_flagged(self):
+        ontology = load_domain_from_yaml_string(VALID_DOMAIN_YAML)
+        # Schema spec requires "at least 3 domain-specific entity types"
+        ontology.entity_types = ontology.entity_types[:2]
+        problems = _validate_ontology_completeness(ontology)
+        assert any("entity_types" in p for p in problems)
+
+    def test_ontology_max_tokens_is_sane(self):
+        # Healthcare YAML is 20,793 bytes ≈ 5–7k tokens. The cap needs to
+        # be comfortably above that to leave room for richer ontologies.
+        assert _ONTOLOGY_MAX_TOKENS >= 16000
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -697,6 +697,111 @@ class TestAllFrameworksRender:
             )
 
 
+class TestCustomDomainRender:
+    """Regression: renderer must complete a full scaffold when the user
+    supplies ``custom_domain_yaml`` (via ``--custom-domain`` LLM generation).
+
+    The original bug at renderer.py:557 imported ``_get_domains_path`` *only*
+    inside the ``else`` branch of the custom-vs-builtin domain check, but
+    referenced it again on the next line for the ``_base.yaml`` copy. On the
+    custom-domain path the import never fired, Python treated the name as a
+    local (because the inner branch wrote to it), and the renderer raised
+    ``UnboundLocalError`` after ``data/ontology.yaml`` was already written —
+    leaving a partial scaffold the user couldn't recover from.
+    """
+
+    def _custom_yaml(self) -> str:
+        """A realistic ontology YAML matching what generate_custom_domain returns."""
+        import importlib.resources
+        # Reuse the healthcare YAML as a stand-in — the renderer doesn't care
+        # whether the YAML came from an LLM or a packaged file, only that it's
+        # valid ontology content keyed by domain.id.
+        path = (
+            importlib.resources.files("create_context_graph")
+            / "domains"
+            / "healthcare.yaml"
+        )
+        return path.read_text()
+
+    def test_renders_full_scaffold_with_custom_domain_yaml(self, tmp_path):
+        from create_context_graph.config import ProjectConfig
+        from create_context_graph.ontology import load_domain_from_yaml_string
+
+        yaml_str = self._custom_yaml()
+        ontology = load_domain_from_yaml_string(yaml_str)
+        config = ProjectConfig(
+            project_name="CustomScaffold",
+            domain=ontology.domain.id,
+            framework="langgraph",
+            custom_domain_yaml=yaml_str,
+        )
+        out = tmp_path / "custom-scaffold"
+        # The original bug raised UnboundLocalError mid-render. Just calling
+        # render() to completion is the regression assertion.
+        ProjectRenderer(config, ontology).render(out)
+
+        # Sanity: the expected key files all exist and are non-empty.
+        for relpath in (
+            "backend/app/agent.py",
+            "backend/app/main.py",
+            "backend/pyproject.toml",
+            "data/ontology.yaml",
+            "data/_base.yaml",
+            "frontend/package.json",
+            "Makefile",
+            ".env",
+            "README.md",
+        ):
+            f = out / relpath
+            assert f.exists(), f"Custom-domain render did not produce {relpath}"
+            assert f.stat().st_size > 0, f"{relpath} is empty"
+
+        # The custom YAML was written verbatim (not the packaged copy).
+        written = (out / "data" / "ontology.yaml").read_text()
+        assert written == yaml_str
+
+        # _base.yaml comes from the package, not the custom YAML.
+        base = (out / "data" / "_base.yaml").read_text()
+        assert "inherits" not in base  # _base.yaml is the root — nothing to inherit
+        assert "entity_types:" in base or "domain:" in base
+
+    def test_base_yaml_copied_regardless_of_custom_domain(self, tmp_path):
+        """The bug surfaced specifically because _base.yaml copy lives OUTSIDE
+        the custom-vs-builtin branch — so both branches must produce it.
+        """
+        from create_context_graph.config import ProjectConfig
+        from create_context_graph.ontology import load_domain, load_domain_from_yaml_string
+
+        # Builtin domain path
+        builtin_cfg = ProjectConfig(
+            project_name="Builtin",
+            domain="healthcare",
+            framework="pydanticai",
+        )
+        builtin_out = tmp_path / "builtin"
+        ProjectRenderer(builtin_cfg, load_domain("healthcare")).render(builtin_out)
+        assert (builtin_out / "data" / "_base.yaml").exists()
+
+        # Custom domain path
+        yaml_str = self._custom_yaml()
+        custom_cfg = ProjectConfig(
+            project_name="Custom",
+            domain="healthcare",
+            framework="pydanticai",
+            custom_domain_yaml=yaml_str,
+        )
+        custom_out = tmp_path / "custom"
+        ProjectRenderer(custom_cfg, load_domain_from_yaml_string(yaml_str)).render(
+            custom_out
+        )
+        assert (custom_out / "data" / "_base.yaml").exists()
+
+        # Both _base.yaml copies must come from the package — identical content.
+        assert (builtin_out / "data" / "_base.yaml").read_text() == (
+            custom_out / "data" / "_base.yaml"
+        ).read_text()
+
+
 class TestFrameworkAgentNotStubFallback:
     """Regression guard for the silent stub-fallback at ``renderer.py:430``.
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -695,3 +695,130 @@ class TestAllFrameworksRender:
             assert pkg_name in pyproject, (
                 f"pyproject.toml for {framework} missing dependency '{pkg_name}'"
             )
+
+
+class TestFrameworkAgentNotStubFallback:
+    """Regression guard for the silent stub-fallback at ``renderer.py:430``.
+
+    Carried forward from the v0.11.0 langgraph bug where a Jinja error in the
+    framework's agent.py.j2 was swallowed by an over-broad ``except Exception``
+    and produced a 36-line stub (``backend/shared/agent_stub.py.j2``) with the
+    same name. Tests like ``test_framework_agent_compiles`` would pass on the
+    stub because it's valid Python — the only way to catch the regression is
+    to assert framework-specific *content* and the absence of the stub's
+    distinguishing phrase.
+
+    The renderer was also tightened to only catch ``TemplateNotFound`` (a real
+    missing-template case) and let Jinja syntax / undefined errors propagate,
+    so a future template breakage becomes a hard test failure instead of a
+    silent stub. Both halves of the fix need to be in place; this test catches
+    the *consequence* if the broad-except is ever re-introduced.
+    """
+
+    # Two distinctive markers per framework — at least one of which is a
+    # unique-to-that-framework symbol (import path, decorator, registry, etc.)
+    # that would NOT appear in the agent_stub.py.j2 fallback.
+    FRAMEWORK_SIGNATURES = {
+        "pydanticai": ["from pydantic_ai import", "@agent.tool"],
+        "claude-agent-sdk": ["import anthropic", "client.messages.stream"],
+        "openai-agents": ["from agents import", "Runner.run"],
+        "langgraph": ["from langgraph.prebuilt import create_react_agent", "ChatAnthropic"],
+        "crewai": ["from crewai import", "Crew("],
+        "strands": ["from strands import Agent", "stream_async"],
+        "google-adk": ["from google.adk", "FunctionTool"],
+        "anthropic-tools": ["TOOL_REGISTRY", "@register_tool"],
+    }
+
+    STUB_FINGERPRINT = "This is a stub implementation"
+
+    @pytest.mark.parametrize("framework", list(FRAMEWORK_SIGNATURES))
+    def test_rendered_agent_is_not_the_stub(self, framework, tmp_path):
+        """The framework template must render — not the stub fallback."""
+        from create_context_graph.config import ProjectConfig
+
+        config = ProjectConfig(
+            project_name="StubGuard",
+            domain="financial-services",
+            framework=framework,
+        )
+        out = tmp_path / f"stub-guard-{framework}"
+        ProjectRenderer(config, load_domain(config.domain)).render(out)
+
+        source = (out / "backend" / "app" / "agent.py").read_text()
+        assert self.STUB_FINGERPRINT not in source, (
+            f"{framework} rendered the agent_stub fallback. "
+            "See renderer.py:430 — only TemplateNotFound should trigger it."
+        )
+        for marker in self.FRAMEWORK_SIGNATURES[framework]:
+            assert marker in source, (
+                f"{framework} agent missing distinctive marker '{marker}'. "
+                "Either the template silently fell back to the stub, or the "
+                "template was edited away from the framework's idiomatic API."
+            )
+
+    def test_stub_fallback_only_when_template_missing(self, tmp_path):
+        """Sanity: the stub is still reachable when the template genuinely
+        doesn't exist. Uses a monkey-patched fw_key to simulate an unmapped
+        framework (the kind of state a half-added new framework would be in).
+        """
+        from unittest.mock import patch
+
+        from create_context_graph.config import ProjectConfig
+
+        config = ProjectConfig(
+            project_name="MissingTemplate",
+            domain="financial-services",
+            framework="pydanticai",  # any valid key — we'll patch resolution
+        )
+        out = tmp_path / "missing-template"
+        renderer = ProjectRenderer(config, load_domain(config.domain))
+
+        # Patch resolved_framework to a key with no template directory.
+        with patch.object(
+            type(config), "resolved_framework", "no-such-framework", create=True
+        ):
+            import warnings
+
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                renderer.render(out)
+                stub_warnings = [
+                    w for w in caught if "placeholder stub" in str(w.message)
+                ]
+                assert stub_warnings, "Missing template must warn loudly"
+
+        source = (out / "backend" / "app" / "agent.py").read_text()
+        assert self.STUB_FINGERPRINT in source
+
+    def test_template_error_propagates(self, tmp_path):
+        """Sanity: a Jinja error (not TemplateNotFound) must surface, NOT
+        silently degrade to the stub.
+
+        Uses a synthetic ``_render_template`` patch to inject an Undefined
+        error that mimics the kind of template bug that previously got
+        swallowed.
+        """
+        from unittest.mock import patch
+
+        from jinja2.exceptions import UndefinedError
+
+        from create_context_graph.config import ProjectConfig
+
+        config = ProjectConfig(
+            project_name="ErrorPropagates",
+            domain="financial-services",
+            framework="pydanticai",
+        )
+        out = tmp_path / "error-propagates"
+        renderer = ProjectRenderer(config, load_domain(config.domain))
+
+        original = renderer._render_template
+
+        def fail_only_agent(template_name, output_path, ctx):
+            if "agents/pydanticai/agent.py.j2" in template_name:
+                raise UndefinedError("simulated template bug")
+            return original(template_name, output_path, ctx)
+
+        with patch.object(renderer, "_render_template", side_effect=fail_only_agent):
+            with pytest.raises(UndefinedError, match="simulated template bug"):
+                renderer.render(out)


### PR DESCRIPTION
## Summary

 Fixes three user-reported bugs in the scaffolding flow and the silent-failure class that produced them. Each had the same shape: an error path was being swallowed (broad `except`, name shadowed by a local-import, default-empty Pydantic field), so users got a partial or unusable scaffold instead of a clear failure.

 ## Fixes

 ### `--framework langgraph` was producing a 36-line stub instead of a real agent

 Root cause: `renderer.py:430` wrapped the per-framework template render in `except Exception:` and fell back to `backend/shared/agent_stub.py.j2` on **any** error. A latent `UndefinedError` in 8 of the agent templates (`{% if param.default is not none %}` against parameters with no `default` key) was tripping that
 broad except — so the rendered `agent.py` was the docstring-`"This is a stub implementation"` placeholder, and existing renderer tests passed because the stub is valid Python.

 Fix:
 - Narrowed the fallback to `except TemplateNotFound` only — a genuine missing-template directory still produces the stub (with a loud `warnings.warn` now), but Jinja runtime errors propagate as hard failures.
 - Patched all 8 agent templates' parameter-default guard to the defensive `{% if param.default is defined and param.default is not none %}` form.

 Regression coverage: `TestFrameworkAgentNotStubFallback` — 8 parametrized signature-marker checks (each framework's rendered `agent.py` must contain framework-specific symbols like `create_react_agent`, `from strands import Agent`, etc.) plus 2 sanity tests (missing template still warns and falls back; Jinja
 `UndefinedError` now propagates).

 ### `--custom-domain` crashed mid-scaffold with `UnboundLocalError`

 Root cause: `from create_context_graph.ontology import _get_domains_path` lived **inside** the `else` branch of the custom-vs-builtin check in `renderer.py`, but the `_base.yaml` copy on the next line referenced the same name unconditionally. On the custom-domain path the import never fired, Python's scope analysis
 treated the name as a function-local, and the renderer raised `UnboundLocalError` after `data/ontology.yaml` had already been written — leaving a partial, unrecoverable scaffold.

 Fix: hoisted `_get_domains_path` to the module-level import. Both paths now complete end-to-end.

 Regression coverage: `TestCustomDomainRender` — full-scaffold smoke against `custom_domain_yaml`, plus a cross-check that `_base.yaml` is byte-identical between the builtin and custom-domain paths.

 ### `--custom-domain` LLM truncation silently produced unusable ontologies

 Root cause: `_llm_generate` used `max_tokens=4096`, but a real domain YAML runs 15–25 KB (5–8k tokens). The LLM truncated mid-`system_prompt`. `DomainOntology` happens to have default-empty for `system_prompt`, `visualization.node_colors`, `agent_tools`, and every other section, so the truncated YAML round-tripped
 through Pydantic as "valid" and the user got a skeletal ontology with no agent system prompt, no visualization colors, and no agent tools.

 Fix — three independent guards:
 1. **Larger token budget**: `_ONTOLOGY_MAX_TOKENS = 16384` for custom-domain generation (back-compat: `_llm_generate`'s `max_tokens` default is still 4096 for all other callers).
 2. **Truncation detection**: `_llm_generate(..., return_stop_reason=True)` returns `(text, stop_reason)`. `stop_reason in ("max_tokens", "length")` (Anthropic / OpenAI) is now treated as a retryable validation error before parsing even runs.
 3. **Completeness check**: new `_validate_ontology_completeness(ontology)` catches the case where the YAML happened to parse — flags missing/empty `system_prompt`, empty `visualization.node_colors`, fewer than 3 `agent_tools`, fewer than 3 `entity_types`. Failures feed the same retry loop.

 Regression coverage: `test_uses_large_max_tokens`, `test_truncation_triggers_retry`, `test_persistent_truncation_raises`, `test_incomplete_ontology_triggers_retry`, plus a new `TestValidateOntologyCompleteness` class (6 tests covering each missing-section case directly).

 ### Missing `anthropic` / `openai` SDK gave a useless error

 Root cause: when run via `uvx create-context-graph --custom-domain ...`, neither SDK is auto-installed (they live in the `generate` extra). The CLI emitted a generic "Install 'anthropic' or 'openai' package" error that didn't tell uvx users how to fix it.

 Fix: actionable error message listing both recipes:
 - `pip install 'create-context-graph[generate]'`
 - `uvx --with anthropic create-context-graph --custom-domain '...' --anthropic-api-key sk-ant-...`
 - Same for `--with openai` / `--openai-api-key`

 `--custom-domain` Click help updated to mention the uvx requirement up front.

 ## Files changed

 ```
 src/create_context_graph/cli.py                                    |   2 +-
 src/create_context_graph/custom_domain.py                          | 101 ++++++++-
 src/create_context_graph/generator.py                              |  38 +++-
 src/create_context_graph/renderer.py                               |  26 ++-
 src/create_context_graph/templates/backend/agents/*/agent.py.j2    |  16 lines (defensive param.default guard, 8 templates)
 src/create_context_graph/templates/backend/shared/memory.py.j2     |   2 +-
 tests/test_custom_domain.py                                        | 129 ++++++++-
 tests/test_renderer.py                                             | 232 +++++++++++
 ```

 15 files, +515 / −33.

 ## Test plan

 - [ ] CI `test` (Python 3.11 + 3.12) green
 - [ ] CI `lint` (ruff) green
 - [ ] Manual: scaffold `--framework langgraph --domain healthcare` → `backend/app/agent.py` is ~300 lines and contains `create_react_agent` + `ChatAnthropic` (not the 36-line stub)
 - [ ] Manual: scaffold with `--custom-domain "<description>" --anthropic-api-key sk-ant-...` → completes end-to-end, `data/ontology.yaml` includes non-empty `system_prompt` and `visualization` sections
 - [ ] Manual: run the same command via `uvx create-context-graph` without `--with anthropic` → error message points at the `uvx --with anthropic` recipe

Fix #28 
Fix #29 