### PR TITLE
prepare for v0.11.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v0.11.3 — Streaming for CrewAI/Strands + NAMS hardening (2026-05-19)
+
+Rolls up streaming chat for the last two non-streaming frameworks, a much better NAMS failure-mode UX (classified errors surfaced in `/health`, memory-backend auto-detection from `.env`), lighter NAMS dependencies, custom-domain robustness fixes, and silent-failure cleanup across all 8 agent templates.
+
+### New Features
+
+- **Streaming chat for CrewAI and Strands.** Both frameworks now implement `handle_message_stream()`, so the `/chat/stream` SSE endpoint streams text deltas as the model produces them — previously these two frameworks emitted tool events live but text only arrived at the end of the run. CrewAI subscribes to `LLMStreamChunkEvent` on the crew event bus; Strands iterates `agent.stream_async()`. Both include a 60s timeout, partial-text fallback assembly, and emit `entities_extracted` / `preferences_detected` events. This closes out the streaming matrix — all 8 frameworks now stream text.
+- **`--import-preview` CLI flag.** Parses a chat export file (`--import-file …` + `--import-type …`) and prints a sanity-check summary (entity counts, conversation date range, sample titles) without scaffolding or ingesting. Useful before committing to a long import of a 1 GB+ ChatGPT/Claude AI export. Implemented in `cli.py::_run_import_preview()`.
+- **NAMS error classification surfaced in `/health`.** New `_classify_memory_error()` in `memory.py.j2` buckets NAMS init failures into `auth` / `rate_limit` / `network` / `config` / `unknown`, with human-readable messages mapped per category (e.g. "NAMS authentication failed — verify MEMORY_API_KEY at https://memory.neo4jlabs.com"). The `/health` endpoint now returns `nams_error`, `nams_error_message`, `nams_error_detail`, and `nams_dashboard` so the frontend can show a useful diagnostic instead of a generic "memory unavailable". Exposed via `get_error_category()` / `get_error_message()` / `get_error_detail()` for the FastAPI startup banner.
+- **Memory-backend auto-detection from `.env`.** New `@model_validator` in `config.py.j2` reconciles `memory_backend` with the credentials actually present in `.env`: flips `nams → bolt` if `MEMORY_API_KEY` is blank but `NEO4J_URI` is set (and vice-versa), printing a warning. An explicit `MEMORY_BACKEND` env var still wins. Default Neo4j credentials in generated `.env` are now empty rather than baked-in placeholder passwords.
+- **Lighter NAMS dependency footprint.** Generated `pyproject.toml` for NAMS scaffolds drops the `sentence-transformers` extra (NAMS does embeddings server-side) — extras shrink from `[litellm,sentence-transformers]` to `[litellm]`. `_resolve_embedding_model()` short-circuits to `None` on NAMS so the generated venv no longer pulls `torch` for a backend that doesn't use local embeddings.
+
+### Bug Fixes
+
+- **Custom-domain renderer crash.** `_get_domains_path()` was imported inside a narrow `try:` scope in `renderer.py`, raising `UnboundLocalError` in the success path after partially writing `ontology.yaml`. Import hoisted to module scope.
+- **Custom-domain generation produced silently-truncated ontologies.** `custom_domain.py` now checks the LLM response `stop_reason` for truncation, validates with Pydantic, and asserts completeness (non-empty `system_prompt` / `visualization` / `agent_tools`) before accepting. Provides actionable retry messages and clearer errors when the Anthropic/OpenAI SDK isn't installed.
+- **Agent-template degradations across all 8 frameworks.** Jinja conditionals that checked `param.default` truthiness were rewritten to `param.default is defined`, and a silent fallback that swallowed Jinja syntax errors was removed so render failures now surface instead of degrading to stub code. Affects every framework template (`anthropic_tools`, `claude_agent_sdk`, `crewai`, `google_adk`, `langgraph`, `openai_agents`, `pydanticai`, `strands`).
+- **Partial streamed text discarded on agent errors.** Strands and CrewAI now accumulate emitted text deltas and return the partial response when a generator raises mid-stream, instead of throwing away accumulated output. Also drops a redundant `RuntimeError` branch from the memory error classifier.
+- **NAMS Docker builds crashed on `spacy download`.** The v0.11.2 fix for the generated `Makefile` is now mirrored in `Dockerfile.backend.j2` via `{% if not is_nams %}` — NAMS images no longer fail at build time on a download command for a package they don't depend on.
+- **Frontend "Ask about" button rendered on non-string entity names.** `ContextGraphView.tsx.j2` adds a `typeof === "string"` guard before reading `.properties.name`.
+- **E2E selector regex out of date.** `e2e/app.spec.ts.j2` regexes updated from `/try a demo scenario/i` to `/try these/i` to match the current welcome card label.
+
+### Documentation
+
+- **`docs/docs/how-to/use-nams.md` — new "Seeding a relationship-rich graph" section.** Documents NAMS's current lack of `add_relationship` REST support and shows two working patterns: (Option A) scaffold with `--self-hosted --demo` for the rich dev experience, flip `MEMORY_BACKEND=nams` for production reads; (Option B) seed bolt first then migrate. Includes a `TODO(nams-relationships)` pointer for the future server-side API.
+- **Generated README (`base/README.md.j2`)** — minor wording updates for the NAMS sign-up flow and the `--import-preview` workflow.
+
+### Internal / CI
+
+- **CodeQL `py/incomplete-url-substring-sanitization` cleanup.** Test assertions in `test_nams_adapter.py` switched from URL substring checks (`"memory.neo4jlabs.com" in env`) to full-URL or content-phrase matches.
+- **Frontend devDeps pinned (`package.json.j2`).** Added `@types/react-dom ^19.0.0`; `overrides` section pins `lodash ^4.17.24` and `postcss ^8.5.10` to dodge known vulnerable transitive versions.
+- **New test coverage:** ~600 new test lines spread across `test_nams_adapter.py` (NAMS error classification, backend auto-detection, Dockerfile spacy guard), `test_renderer.py` (template-degradation guards, custom-domain regression), `test_custom_domain.py` (truncation/completeness validation), `test_generated_project.py` (CrewAI/Strands streaming surface), `test_chat_import.py` (`--import-preview`), `test_cli.py`, `test_doc_snippets.py`, and `test_routes_integration.py`.
+
 ## v0.11.2 — Post-release stabilization + pre-release smoke-render target (2026-05-19)
 
 Rolls up three follow-up fixes surfaced by running v0.11.0/v0.11.1 end-to-end on a fresh machine, plus a durable safeguard against the same class of bugs.

--- a/docs/docs/how-to/switch-agent-frameworks.md
+++ b/docs/docs/how-to/switch-agent-frameworks.md
@@ -16,12 +16,12 @@ Create Context Graph supports 8 agent frameworks. The framework choice only affe
 | **Claude Agent SDK** | `claude-agent-sdk` | Anthropic's SDK with dict-based tool definitions and a bounded agentic loop (max 15 iterations) | Full |
 | **OpenAI Agents SDK** | `openai-agents` | OpenAI's agent framework with `@function_tool` decorators and `Runner.run()` | Full |
 | **LangGraph** | `langgraph` | LangChain's graph-based agent runtime with `@tool` and `create_react_agent()` | Full |
-| **CrewAI** | `crewai` | Multi-agent framework with `Agent`, `Task`, and `Crew` abstractions (uses Anthropic LLM, thread-safe async bridging) | Tools only |
-| **Strands** | `strands` | Agent framework using Anthropic models with `@tool` decorators (thread-safe async bridging) | Tools only |
+| **CrewAI** | `crewai` | Multi-agent framework with `Agent`, `Task`, and `Crew` abstractions (uses Anthropic LLM, thread-safe async bridging) | Full |
+| **Strands** | `strands` | Agent framework using Anthropic models with `@tool` decorators (thread-safe async bridging) | Full |
 | **Google ADK** | `google-adk` | Google's Agent Development Kit with `FunctionTool` and Gemini models (requires `GOOGLE_API_KEY`) | Full |
 | **Anthropic Tools** | `anthropic-tools` | Modular agent framework with `@register_tool` registry and bounded Anthropic API agentic loop (max 15 iterations) | Full |
 
-**Streaming column:** "Full" means token-by-token text streaming + real-time tool call events. "Tools only" means tool call events stream in real-time, but the text response arrives all at once after the agent finishes. All frameworks use the same SSE (Server-Sent Events) protocol.
+**Streaming column:** "Full" means token-by-token text streaming + real-time tool call events. All frameworks use the same SSE (Server-Sent Events) protocol; CrewAI and Strands run synchronously in a worker thread but stream both text and tool events via framework-specific hooks (`LLMStreamChunkEvent` and `agent.stream_async()`).
 
 ## Choosing a Framework During Scaffolding
 
@@ -56,7 +56,7 @@ Only one file varies between frameworks: **`backend/app/agent.py`**. This file c
 - The agent initialization and model configuration
 - Tool definitions generated from your domain's `agent_tools` ontology
 - The `handle_message()` async function that the FastAPI routes call
-- (For full-streaming frameworks) The `handle_message_stream()` async function for SSE text streaming
+- The `handle_message_stream()` async function for SSE text streaming (all 8 frameworks)
 
 Each framework template uses the framework's idiomatic patterns (decorators, classes, registries) but exposes the same interface.
 

--- a/docs/docs/reference/cli-options.md
+++ b/docs/docs/reference/cli-options.md
@@ -86,6 +86,7 @@ The CLI chooses one of two memory backends per project:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
+| `--import-preview` | `flag` | `false` | Parse `--import-file` and print a summary (conversation counts, date range, sample titles) without scaffolding or ingesting. Useful as a sanity check before a long ingest of a multi-GB export. Requires `--import-type` and `--import-file`. |
 | `--import-type` | `choice` | -- | `claude-ai` or `chatgpt`. Must pair with `--import-file`. |
 | `--import-file` | `path` | -- | Path to chat export (`.zip`, `.json`, `.jsonl`). |
 | `--import-depth` | `choice` | `fast` | `fast` (messages) or `deep` (messages + tool call traces). |

--- a/docs/docs/reference/framework-comparison.md
+++ b/docs/docs/reference/framework-comparison.md
@@ -19,8 +19,8 @@ Start with **PydanticAI** -- it offers the best combination of type safety, full
 | **OpenAI Agents SDK** | OpenAI | Full (text + tools) | Native async | Requires `OPENAI_API_KEY`. Text-matching tools need specific search terms. |
 | **LangGraph** | Anthropic (configurable) | Full (text + tools) | Native async | Slightly higher startup (graph compilation). Rich observability hooks. |
 | **Anthropic Tools** | Anthropic | Full (text + tools) | Native async | No framework dependency. Direct API control over agentic loop. |
-| **Strands** | Anthropic | Tools only | Thread-bridged | Sync framework in worker thread. Text arrives at end, tools stream live. |
-| **CrewAI** | Anthropic | Tools only | Thread-bridged | Higher startup (multi-agent init). Text arrives at end. Needs `crewai[anthropic]`. |
+| **Strands** | Anthropic | Full (text + tools) | Thread-bridged | Sync framework in worker thread; text streams via `agent.stream_async()`. |
+| **CrewAI** | Anthropic | Full (text + tools) | Thread-bridged | Higher startup (multi-agent init); text streams via `LLMStreamChunkEvent`. Needs `crewai[anthropic]`. |
 | **Google ADK** | Google Gemini | Full (text + tools) | Native async | Requires `GOOGLE_API_KEY`. Uses `nest_asyncio` for reentrant async. |
 
 ## Choosing a Framework
@@ -51,9 +51,7 @@ Uses Google's Gemini models via the Agent Development Kit. Requires a separate G
 
 ## Streaming Behavior
 
-**Full streaming** (6 frameworks): Text tokens stream to the frontend as they're generated, and tool calls appear in real-time in the tool call timeline. The user sees the response build progressively.
-
-**Tools-only streaming** (CrewAI, Strands): Tool call events stream in real-time, but the final text response arrives all at once after the agent completes. This is because these frameworks run synchronously in a worker thread.
+**Full streaming (all 8 frameworks):** text tokens stream to the frontend as they're generated, and tool calls appear in real-time in the tool call timeline. CrewAI and Strands run synchronously in a worker thread; their text streams via framework-specific hooks (`LLMStreamChunkEvent` and `agent.stream_async()` respectively) and tool events stream via the thread-safe `CypherResultCollector`. The other six frameworks stream via native async APIs.
 
 ## Thread Safety
 

--- a/docs/docs/reference/generated-project-structure.md
+++ b/docs/docs/reference/generated-project-structure.md
@@ -126,7 +126,7 @@ async def handle_message(
     """Returns {"response": str, "session_id": str, "graph_data": dict | None}"""
 ```
 
-For frameworks that support text streaming (PydanticAI, Anthropic Tools, Claude Agent SDK, OpenAI Agents, LangGraph, Google ADK), the agent also exports:
+All 8 frameworks also export a streaming variant for the `/chat/stream` SSE endpoint:
 
 ```python
 async def handle_message_stream(

--- a/docs/docs/tutorials/import-chat-history.md
+++ b/docs/docs/tutorials/import-chat-history.md
@@ -62,6 +62,19 @@ The export email typically arrives within a few minutes. Check your spam folder 
 ChatGPT exports include DALL-E generated images and uploaded files alongside the conversation JSON. The import process only reads `conversations.json` -- image files are ignored.
 :::
 
+## Step 1.5: Preview your export (optional, recommended)
+
+Before scaffolding a full project, you can preview what will be imported. This parses the export file and prints a summary (conversation count, date range, sample titles) without creating any files or writing to Neo4j — useful for sanity-checking a multi-GB export before committing to a long ingest:
+
+```bash
+uvx create-context-graph \
+  --import-preview \
+  --import-type claude-ai \
+  --import-file ~/Downloads/claude-export.zip
+```
+
+The same flag works for ChatGPT exports — swap `--import-type chatgpt` and point `--import-file` at the ChatGPT `.zip`. Combine with any of the `--import-filter-*` flags below to preview a filtered subset.
+
 ## Step 2: Scaffold the project
 
 Run the CLI with the `--import-type` and `--import-file` flags:
@@ -162,6 +175,7 @@ uvx create-context-graph my-chat-graph \
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--import-preview` | `flag` | `false` | Parse the export file and print a summary without scaffolding or ingesting. Requires `--import-type` and `--import-file`. |
 | `--import-type` | `choice` | -- | Import source: `claude-ai` or `chatgpt` |
 | `--import-file` | `path` | -- | Path to export file (`.zip`, `.json`, `.jsonl`) |
 | `--import-depth` | `choice` | `fast` | Extraction depth: `fast` or `deep` |

--- a/docs/docs/whats-new.md
+++ b/docs/docs/whats-new.md
@@ -7,7 +7,32 @@ title: "What's New"
 
 Recent additions and changes to create-context-graph and its documentation.
 
-## v0.11.0 (Current) — NAMS by default + LiteLLM
+## v0.11.3 (Current) — Streaming for CrewAI/Strands + NAMS hardening
+
+This release brings the last two agent frameworks onto full text streaming (CrewAI and Strands now stream both text and tool events via SSE — previously they streamed tool events only), adds a classified error path for NAMS failures so the frontend can surface useful diagnostics, and ships memory-backend auto-detection so the CLI does the right thing when your `.env` credentials and `MEMORY_BACKEND` don't line up.
+
+### New Features
+
+- **All 8 frameworks now stream text** — CrewAI gains streaming via the `LLMStreamChunkEvent` event bus; Strands gains streaming via `agent.stream_async()`. Both still run synchronously in a worker thread, with thread-safe text and tool events streamed through the `CypherResultCollector`. See [Framework Comparison](/docs/reference/framework-comparison).
+- **`--import-preview` flag** — parse a Claude AI / ChatGPT export file and print a sanity-check summary (conversation count, date range, sample titles) without scaffolding or ingesting. Useful before committing to a multi-GB import. See [Import Chat History](/docs/tutorials/import-chat-history).
+- **Classified NAMS errors in `/health`** — when the memory layer fails to connect, `/health` now returns `nams_error` (one of `auth` / `rate_limit` / `network` / `config` / `unknown`), `nams_error_message` (human-readable), `nams_error_detail`, and `nams_dashboard` — so the frontend can show a useful diagnostic instead of a generic "memory unavailable".
+- **Memory-backend auto-detection** — the generated `config.py` reconciles `MEMORY_BACKEND` with the credentials actually present in `.env`: flips `nams → bolt` if `MEMORY_API_KEY` is blank but `NEO4J_URI` is set, and vice-versa, with a warning. An explicit `MEMORY_BACKEND` env var still wins.
+- **Lighter NAMS dependency footprint** — generated NAMS scaffolds no longer pull `sentence-transformers` (and therefore `torch`), since NAMS does embeddings server-side. The `neo4j-agent-memory` extras shrink from `[litellm,sentence-transformers]` to `[litellm]`.
+
+### Bug Fixes
+
+- Agent-template degradations fixed across all 8 frameworks (Jinja `param.default is defined` guards; silent render-failure fallback removed so scaffold errors surface instead of producing stub code).
+- Custom-domain generation now detects LLM-truncated ontologies via `stop_reason` and validates completeness (non-empty `system_prompt` / `visualization` / `agent_tools`) before writing.
+- Strands and CrewAI now return accumulated text deltas on streaming errors instead of discarding them.
+- NAMS Docker images no longer fail to build on the `spacy download` step (the spacy guard from v0.11.2's `Makefile` is now mirrored in `Dockerfile.backend`).
+
+### New Documentation
+
+- New **"Seeding a relationship-rich graph"** section in [Use NAMS](/docs/how-to/use-nams) — explains how to seed with `--self-hosted --demo` (which writes the full demo graph including relationships) and then flip `MEMORY_BACKEND=nams` once `add_relationship` lands in the NAMS REST API.
+
+---
+
+## v0.11.0 — NAMS by default + LiteLLM
 
 This release flips the default memory backend from self-hosted Neo4j to the hosted **Neo4j Agent Memory Service (NAMS)** and adds **LiteLLM** provider injection for the memory layer.
 

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-context-graph",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Interactive CLI scaffolding tool for domain-specific context graph applications with Neo4j",
   "bin": {
     "create-context-graph": "./bin/create-context-graph"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "create-context-graph"
-version = "0.11.2"
+version = "0.11.3"
 description = "Interactive CLI scaffolding tool for domain-specific context graph applications"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/create_context_graph/__init__.py
+++ b/src/create_context_graph/__init__.py
@@ -14,4 +14,4 @@
 
 """Create Context Graph - Interactive CLI scaffolding tool for domain-specific context graph applications."""
 
-__version__ = "0.9.2"
+__version__ = "0.11.3"


### PR DESCRIPTION
 ## Summary

 Release-prep for v0.11.3. The actual feature/bugfix work landed in `main` via #43 — this PR is just the version bumps, CHANGELOG entry, and docs-site updates so the release can be tagged.

 - **Version bumps** to `0.11.3` across `pyproject.toml`, `npm-wrapper/package.json`, and `src/create_context_graph/__init__.py` (the `__init__.py` was stale at `0.9.2` since the v0.9.2 tag — bringing it in line in this PR).
 - **CHANGELOG entry** for v0.11.3 grouped under New Features / Bug Fixes / Documentation / Internal. Highlights: streaming for CrewAI and Strands (closes out the 8/8 streaming matrix), `--import-preview` CLI flag, classified NAMS errors surfaced in `/health`, memory-backend auto-detection from `.env`, lighter NAMS
 dep footprint (no `sentence-transformers` / `torch` on NAMS scaffolds), custom-domain truncation/completeness validation, partial-streamed-text recovery on errors, NAMS Dockerfile spacy guard.
 - **Docs site updates** (Docusaurus, `docs/docs/`):
   - `whats-new.md` — new `v0.11.3 (Current)` section at the top; previous `v0.11.0 (Current)` heading demoted.
   - `reference/framework-comparison.md` — CrewAI and Strands flipped from `Tools only` to `Full (text + tools)` in the comparison table; "Streaming Behavior" section rewritten to a single "all 8 frameworks" paragraph (the "Tools-only streaming" paragraph removed).
   - `how-to/switch-agent-frameworks.md` — same streaming-claim cleanup, second location.
   - `reference/cli-options.md` — `--import-preview` row added to the Chat History Import table.
   - `tutorials/import-chat-history.md` — new "Step 1.5: Preview your export" section with a worked example, plus a row added to the flags-reference table.
   - `reference/generated-project-structure.md` — streaming framework list (line 129) replaced with "all 8 frameworks".

 ## Test plan

 - [ ] CI `test` job passes (1,177+ fast unit tests on Python 3.11 and 3.12).
 - [ ] CI `lint` job passes (`ruff`).
 - [ ] `grep -rn "Tools only\|6 frameworks\|Tools-only streaming" docs/docs/` returns no hits (historical v0.9.0 entry's "6 frameworks" claim is intentional).
 - [ ] `cd docs && npm run build` succeeds (no MDX errors, no broken links from the new `/docs/...` cross-references).
 - [ ] `head -5 CHANGELOG.md` shows `## v0.11.3 — …` at the top.
 - [ ] `grep -n version pyproject.toml npm-wrapper/package.json src/create_context_graph/__init__.py` all show `0.11.3`.
 - [ ] Once merged, tag `v0.11.3` from `main` to trigger the `publish-pypi.yml` and `publish-npm.yml` workflows.