### PR TITLE
Route ingestion through NAMS endpoints 

### DIFF
--- a/docs/docs/explanation/memory-backends.md
+++ b/docs/docs/explanation/memory-backends.md
@@ -37,20 +37,21 @@ But the two backends have **different operational profiles**, and each makes sen
 
 The most important asymmetry today is what NAMS REST **doesn't** expose. The library raises `NotSupportedError` on these:
 
-- `add_relationship(...)` — relationships between domain entities cannot be created.
+- `add_relationship(...)` — no REST endpoint yet for native edges between domain entities.
 - `add_preference(...)` / `add_fact(...)` — preferences and facts have no REST endpoints.
 - Arbitrary Cypher writes via `client.query.cypher(...)` — read-only on NAMS.
 - Schema DDL (`CREATE CONSTRAINT`, `CREATE INDEX`) — NAMS owns its schema.
 
-The CLI's NAMS ingest path **does best-effort B-partial port**:
+The CLI and the generated `import_data.py` use a hybrid write shape that captures everything connectors emit without losing structure:
 
-- **Entities** — uses `add_entity`. NAMS REST accepts only `{name, type, description}`; the CLI serializes other properties into the description field as markdown so the property pane stays useful.
-- **Documents** — stored as `short_term.add_message(role="document")`, with title in metadata.
-- **Decision traces** — via `reasoning.start_trace / add_step / complete_trace`.
-- **Relationships** — logged-skipped. The frontend's graph view shows entities without edges on NAMS.
-- **Preferences / facts** — `auto_preferences` is forced off on NAMS. `auto_extract` still runs but extracted relationships are silently dropped.
+- **Entities** — `add_entity`. NAMS REST accepts only `{name, type, description}`; both ingestors serialize other properties into `description` as markdown so the property pane stays useful.
+- **Relationships** — **encoded** into the source entity's `description` as a fenced ```ccg-edges``` YAML block (deterministic, distinctively marked). The frontend graph view parses these out and renders edges. A one-shot migration replays them as native edges when NAMS adds `add_relationship` — the seam is `_build_ccg_edges_block` in `ingest.py`.
+- **Documents** — **dual-tracked**: `long_term.add_entity(name=title, type=OBJECT)` so the doc is a queryable entity (matches the bolt `:Document` shape), plus `short_term.add_message(role="document")` so the NAMS extractor can mine the prose. The `/documents` endpoint reads from long_term entities; short-term entries are extraction fuel, not the source of truth.
+- **Entity bodies** — connectors declare a `BODY_FIELDS = {label: property}` map; the named body field is also fed through `add_message` so the extractor sees comment bodies, issue descriptions, etc. Pure-metadata entities (Person, Project, Label) skip this channel.
+- **Decision traces** — `reasoning.start_trace / add_step / complete_trace` (unchanged).
+- **Preferences / facts** — still unsupported on NAMS REST. `auto_preferences` is forced off on NAMS; `auto_extract` runs but extracted edges are dropped (the encoded `ccg-edges` block covers structured edges instead).
 
-These limits reflect the current state of NAMS REST (v0.4). They'll narrow over time as upstream adds endpoints.
+These limits reflect the current state of NAMS REST (v0.4) and will narrow as upstream adds endpoints. The contract test `tests/test_nams_ingest_parity.py` pins the CLI and the scaffolded importer to the same NAMS call sequence so the two paths can't drift.
 
 ## Choosing per-project
 

--- a/docs/docs/how-to/use-nams.md
+++ b/docs/docs/how-to/use-nams.md
@@ -76,54 +76,40 @@ The NAMS REST API exposes a narrower write surface than bolt Cypher. The CLI doe
 |---|---|---|
 | Entity create (`add_entity`) | ✅ name + type + description only — other properties dropped | ✅ full properties |
 | Entity properties | ⚠️ Serialized into `description` field as markdown | ✅ first-class on the node |
-| Relationships | ❌ Not yet exposed | ✅ Cypher MERGE |
+| Relationships | ⚠️ Encoded into source entity's `description` as a fenced `ccg-edges` YAML block (migrates to native edges when NAMS adds `add_relationship`) | ✅ Cypher MERGE |
 | Preferences / facts | ❌ Not yet exposed | ✅ `add_preference`, `add_fact` |
 | Decision traces | ✅ via `reasoning.start_trace` | ✅ via Cypher |
-| Documents | ✅ as `short_term.add_message(role="document")` | ✅ as `:Document` nodes |
+| Documents | ✅ dual-tracked: `long_term.add_entity(type=OBJECT)` + `short_term.add_message(role="document")` | ✅ as `:Document` nodes |
 | Schema DDL | ❌ NAMS owns schema | ✅ `CREATE CONSTRAINT` etc. |
 | GDS algorithms | ❌ 501 Not Implemented | ✅ |
 | Arbitrary Cypher writes | ❌ Read-only | ✅ |
 
-The frontend handles these gaps transparently — graph view shows entities without edges, document browser pulls from the `documents` session, decision trace panel reads via the NAMS reasoning API.
+The frontend handles these gaps transparently — the graph view shows entities and parses `ccg-edges` blocks out of descriptions to display edges, the document browser reads from long-term `Document` entities, and the decision trace panel reads via the NAMS reasoning API.
 
 ## Seeding a relationship-rich graph for a NAMS project
 
-NAMS doesn't yet expose relationship writes via its REST API, so `make seed` on a NAMS scaffold creates entities but skips edges. The graph view shows disconnected nodes.
+NAMS REST has no `add_relationship` endpoint yet, so on NAMS scaffolds the ingest pipeline encodes each entity's outbound edges into a fenced `ccg-edges` YAML block appended to its `description`:
 
-If you need the full POLE-typed graph with relationships — for instance, to demo `expand_node` from the chat or to run agent tools that traverse edges — there are two workarounds.
+```ccg-edges
+- type: TREATED_AT
+  target: Mercy General
+  target_label: Hospital
+```
 
-### Option A — Bolt for development, NAMS for production reads
+The graph view recognizes this marker and renders the edges. The agent reads them out of the entity description naturally. When NAMS gains `add_relationship`, a one-shot migration parses these blocks and replays them as native edges — no schema change.
 
-Most teams adopt this pattern:
+If you'd rather have native graph edges today (for `expand_node`, GDS algorithms, or arbitrary Cypher traversal), scaffold with `--self-hosted`:
 
-1. **Scaffold the development project with `--self-hosted`:**
-   ```bash
-   uvx create-context-graph my-app --domain healthcare \
-     --framework strands --self-hosted --demo
-   ```
-   The `--demo` flag triggers `--reset-database --demo-data --ingest`, which seeds the full 80-entity / 180-edge demo graph into your local Neo4j.
+```bash
+uvx create-context-graph my-app --domain healthcare \
+  --framework strands --self-hosted --demo
+```
 
-2. **Demo, develop, and validate against the bolt graph.** Agent tools, expand actions, and GDS algorithms all work.
-
-3. **Promote to NAMS for production by flipping `MEMORY_BACKEND` in `.env`:**
-   ```bash
-   MEMORY_BACKEND=nams
-   MEMORY_API_KEY=sk-nams-...
-   ```
-   On NAMS the agent will populate memory through conversation. Pre-existing relationships from the bolt seeding stay in the bolt database; NAMS starts fresh.
-
-### Option B — Dual-run during seeding only
-
-If you want NAMS in production but a relationship-rich starting state:
-
-1. Run `make seed` against bolt to seed the local graph.
-2. Migrate manually: extract entities + relationships from bolt and re-ingest into NAMS as graph-shaped descriptions (relationships flattened into the `description` field). The `--ingest` path already does the entity half; the relationship half requires a custom script today.
-
-This is operationally awkward — most users stick with Option A until NAMS adds `add_relationship` to the REST API.
+The `--demo` flag triggers `--reset-database --demo-data --ingest`, which seeds the full 80-entity / 180-edge demo graph into your local Neo4j via native Cypher MERGE — no `ccg-edges` encoding because bolt can write real edges. You can develop against the bolt graph and later promote to NAMS by flipping `MEMORY_BACKEND` in `.env`.
 
 ### When NAMS adds relationship writes
 
-The `ingest.py` module has a `# TODO(nams-relationships)` marker. When the upstream library ships `MemoryClient.add_relationship`, scaffolding with NAMS + `--demo` will produce the full graph without the bolt-first dance.
+Both `ingest.py` and the generated `import_data.py` emit relationships via the shared `ccg-edges` marker. When the upstream library ships `MemoryClient.add_relationship`, the encoding logic in `_build_ccg_edges_block` is the single seam to replace — both consumers update via the contract test in `tests/test_nams_ingest_parity.py`.
 
 ## Switching backends after scaffold
 

--- a/src/create_context_graph/connectors/__init__.py
+++ b/src/create_context_graph/connectors/__init__.py
@@ -83,6 +83,13 @@ class BaseConnector(ABC):
     service_description: str = ""
     requires_oauth: bool = False
 
+    # Per-entity-type mapping declaring which property carries the prose body
+    # for an entity. The ingestor reads this to decide which entities should
+    # also flow through ``short_term.add_message`` so NAMS-side entity
+    # extraction can mine the body for additional structure. Pure-metadata
+    # entities (Person, Project, Label) omit themselves from this dict.
+    BODY_FIELDS: dict[str, str] = {}
+
     @abstractmethod
     def authenticate(self, credentials: dict[str, str]) -> None:
         """Authenticate with the service using provided credentials."""

--- a/src/create_context_graph/connectors/chatgpt_connector.py
+++ b/src/create_context_graph/connectors/chatgpt_connector.py
@@ -58,6 +58,8 @@ class ChatGPTConnector(BaseConnector):
     )
     requires_oauth = False
 
+    BODY_FIELDS = {"Message": "content"}
+
     def __init__(self) -> None:
         self._file_path: str = ""
         self._depth: str = "fast"

--- a/src/create_context_graph/connectors/claude_ai_connector.py
+++ b/src/create_context_graph/connectors/claude_ai_connector.py
@@ -58,6 +58,8 @@ class ClaudeAIConnector(BaseConnector):
     )
     requires_oauth = False
 
+    BODY_FIELDS = {"Message": "content"}
+
     def __init__(self) -> None:
         self._file_path: str = ""
         self._depth: str = "fast"

--- a/src/create_context_graph/connectors/claude_code_connector.py
+++ b/src/create_context_graph/connectors/claude_code_connector.py
@@ -65,6 +65,8 @@ class ClaudeCodeConnector(BaseConnector):
     )
     requires_oauth = False
 
+    BODY_FIELDS = {"Message": "content"}
+
     def __init__(self) -> None:
         self._base_path: Path | None = None
         self._scope: str = "current"

--- a/src/create_context_graph/connectors/google_workspace_connector.py
+++ b/src/create_context_graph/connectors/google_workspace_connector.py
@@ -116,6 +116,11 @@ class GoogleWorkspaceConnector(BaseConnector):
     )
     requires_oauth = True
 
+    # DecisionThread and Reply both carry the actual comment/reply body in
+    # their ``content`` field. Document descriptions are short metadata
+    # captions, not bodies — already covered by Document fixture entries.
+    BODY_FIELDS = {"DecisionThread": "content", "Reply": "content"}
+
     def __init__(self) -> None:
         self._use_gws: bool = False
         self._access_token: str = ""

--- a/src/create_context_graph/connectors/linear_connector.py
+++ b/src/create_context_graph/connectors/linear_connector.py
@@ -127,6 +127,10 @@ class LinearConnector(BaseConnector):
     service_description = "Import issues, projects, cycles, and team data from Linear"
     requires_oauth = False
 
+    # Issue descriptions and ProjectUpdate bodies are already converted to
+    # :Document entities at fetch time, so we only need Comment.body here.
+    BODY_FIELDS = {"Comment": "body"}
+
     def __init__(self):
         self._api_key: str = ""
         self._team_key: str = ""

--- a/src/create_context_graph/connectors/local_file_connector.py
+++ b/src/create_context_graph/connectors/local_file_connector.py
@@ -60,6 +60,11 @@ class LocalFileConnector(BaseConnector):
     )
     requires_oauth = False
 
+    # Document/Section description fields carry the actual prose body (plus
+    # uri: pointer lines to children). Feed both through add_message so NAMS
+    # extraction can find named entities mentioned in section text.
+    BODY_FIELDS = {"Document": "description", "Section": "description"}
+
     def __init__(self) -> None:
         self._paths: list[Path] = []
         self._pattern: str = "**/*"

--- a/src/create_context_graph/ingest.py
+++ b/src/create_context_graph/ingest.py
@@ -848,15 +848,15 @@ def reset_memory_store(config: "ProjectConfig") -> None:
 
 def _coerce_ingest_config(
     ontology: DomainOntology,
-    config_or_neo4j_uri: "ProjectConfig | str",
+    config_or_uri: "ProjectConfig | str",
     neo4j_username: str | None,
     neo4j_password: str | None,
 ) -> "ProjectConfig":
     """Accept either a ProjectConfig or the legacy bolt Neo4j credentials."""
     from create_context_graph.config import ProjectConfig
 
-    if isinstance(config_or_neo4j_uri, ProjectConfig):
-        return config_or_neo4j_uri
+    if isinstance(config_or_uri, ProjectConfig):
+        return config_or_uri
 
     if neo4j_username is None or neo4j_password is None:
         raise TypeError(
@@ -868,7 +868,7 @@ def _coerce_ingest_config(
         project_name=ontology.domain.name,
         domain=ontology.domain.id,
         memory_backend="bolt",
-        neo4j_uri=config_or_neo4j_uri,
+        neo4j_uri=config_or_uri,
         neo4j_username=neo4j_username,
         neo4j_password=neo4j_password,
     )
@@ -877,7 +877,7 @@ def _coerce_ingest_config(
 def ingest_data(
     fixture_path: Path,
     ontology: DomainOntology,
-    config_or_neo4j_uri: "ProjectConfig | str",
+    config_or_uri: "ProjectConfig | str",
     neo4j_username: str | None = None,
     neo4j_password: str | None = None,
     body_fields: dict[str, str] | None = None,
@@ -887,12 +887,16 @@ def ingest_data(
     Accepts either a ``ProjectConfig`` or the legacy bolt-only
     ``(neo4j_uri, neo4j_username, neo4j_password)`` arguments.
 
+    Examples:
+        ingest_data(fixture_path, ontology, config)
+        ingest_data(fixture_path, ontology, neo4j_uri, neo4j_username, neo4j_password)
+
     ``body_fields`` is the union of every active connector's ``BODY_FIELDS``
     map; the demo fixture path passes ``None``/``{}`` because pre-generated
     fixtures don't carry connector-specific body conventions.
     """
     config = _coerce_ingest_config(
-        ontology, config_or_neo4j_uri, neo4j_username, neo4j_password
+        ontology, config_or_uri, neo4j_username, neo4j_password
     )
 
     if not fixture_path.exists():

--- a/src/create_context_graph/ingest.py
+++ b/src/create_context_graph/ingest.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -61,6 +62,7 @@ console = Console()
 
 
 _RESERVED_DESCRIPTION_KEYS = {"name", "description", "domain", "id", "uuid"}
+_SAFE_CYPHER_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _format_attribute(key: str, value: Any) -> str | None:
@@ -113,6 +115,13 @@ def _get_pole_type(label: str, ontology: DomainOntology) -> str:
         if et.label == label:
             return et.pole_type
     return "OBJECT"
+
+
+def _require_safe_cypher_identifier(value: str, kind: str) -> str:
+    """Validate a dynamic Cypher identifier before string interpolation."""
+    if isinstance(value, str) and _SAFE_CYPHER_IDENTIFIER_RE.fullmatch(value):
+        return value
+    raise ValueError(f"Unsafe Cypher {kind}: {value!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -494,10 +503,13 @@ async def _ingest_with_memory_client(
             rel_count = 0
             for rel in relationships:
                 try:
+                    rel_type = _require_safe_cypher_identifier(
+                        rel.get("type", ""), "relationship type",
+                    )
                     cypher = f"""
                     MATCH (a {{name: $source_name}})
                     MATCH (b {{name: $target_name}})
-                    MERGE (a)-[r:{rel['type']}]->(b)
+                    MERGE (a)-[r:{rel_type}]->(b)
                     RETURN type(r)
                     """
                     await client.graph.execute_write(
@@ -643,10 +655,15 @@ async def _ingest_with_driver(
         entities = fixture_data.get("entities", {})
         async with driver.session() as session:
             for label, items in entities.items():
+                try:
+                    safe_label = _require_safe_cypher_identifier(label, "label")
+                except ValueError as e:
+                    console.print(f"  [yellow]Warning:[/yellow] Label {label!r}: {e}")
+                    continue
                 for item in items:
                     enriched = {**item, "domain": ontology.domain.id}
                     set_clauses = ", ".join(f"n.{k} = ${k}" for k in enriched.keys())
-                    cypher = f"MERGE (n:{label} {{name: $name, domain: $domain}}) SET {set_clauses}"
+                    cypher = f"MERGE (n:{safe_label} {{name: $name, domain: $domain}}) SET {set_clauses}"
                     try:
                         await session.run(cypher, enriched)
                         entity_count += 1
@@ -659,12 +676,21 @@ async def _ingest_with_driver(
         relationships = fixture_data.get("relationships", [])
         async with driver.session() as session:
             for rel in relationships:
-                cypher = f"""
-                MATCH (a:{rel['source_label']} {{name: $source_name}})
-                MATCH (b:{rel['target_label']} {{name: $target_name}})
-                MERGE (a)-[r:{rel['type']}]->(b)
-                """
                 try:
+                    source_label = _require_safe_cypher_identifier(
+                        rel.get("source_label", ""), "source label",
+                    )
+                    target_label = _require_safe_cypher_identifier(
+                        rel.get("target_label", ""), "target label",
+                    )
+                    rel_type = _require_safe_cypher_identifier(
+                        rel.get("type", ""), "relationship type",
+                    )
+                    cypher = f"""
+                    MATCH (a:{source_label} {{name: $source_name}})
+                    MATCH (b:{target_label} {{name: $target_name}})
+                    MERGE (a)-[r:{rel_type}]->(b)
+                    """
                     await session.run(cypher, {
                         "source_name": rel["source_name"],
                         "target_name": rel["target_name"],

--- a/src/create_context_graph/ingest.py
+++ b/src/create_context_graph/ingest.py
@@ -846,18 +846,55 @@ def reset_memory_store(config: "ProjectConfig") -> None:
 # ---------------------------------------------------------------------------
 
 
+def _coerce_ingest_config(
+    ontology: DomainOntology,
+    config_or_neo4j_uri: "ProjectConfig | str",
+    neo4j_username: str | None,
+    neo4j_password: str | None,
+) -> "ProjectConfig":
+    """Accept either a ProjectConfig or the legacy bolt Neo4j credentials."""
+    from create_context_graph.config import ProjectConfig
+
+    if isinstance(config_or_neo4j_uri, ProjectConfig):
+        return config_or_neo4j_uri
+
+    if neo4j_username is None or neo4j_password is None:
+        raise TypeError(
+            "ingest_data() requires neo4j_username and neo4j_password when called "
+            "with the legacy (neo4j_uri, neo4j_username, neo4j_password) signature"
+        )
+
+    return ProjectConfig(
+        project_name=ontology.domain.name,
+        domain=ontology.domain.id,
+        memory_backend="bolt",
+        neo4j_uri=config_or_neo4j_uri,
+        neo4j_username=neo4j_username,
+        neo4j_password=neo4j_password,
+    )
+
+
 def ingest_data(
     fixture_path: Path,
     ontology: DomainOntology,
-    config: "ProjectConfig",
+    config_or_neo4j_uri: "ProjectConfig | str",
+    neo4j_username: str | None = None,
+    neo4j_password: str | None = None,
     body_fields: dict[str, str] | None = None,
 ) -> None:
     """Ingest fixture data into the configured memory backend.
+
+    Accepts either a ``ProjectConfig`` or the legacy bolt-only
+    ``(neo4j_uri, neo4j_username, neo4j_password)`` arguments.
 
     ``body_fields`` is the union of every active connector's ``BODY_FIELDS``
     map; the demo fixture path passes ``None``/``{}`` because pre-generated
     fixtures don't carry connector-specific body conventions.
     """
+    config = _coerce_ingest_config(
+        ontology, config_or_neo4j_uri, neo4j_username, neo4j_password
+    )
+
     if not fixture_path.exists():
         console.print(f"[red]Fixture file not found:[/red] {fixture_path}")
         return

--- a/src/create_context_graph/ingest.py
+++ b/src/create_context_graph/ingest.py
@@ -18,14 +18,23 @@ Two backend-specific paths:
 
 * **NAMS** (default) — entities via ``client.long_term.add_entity`` with all
   non-name properties serialized into the entity ``description`` field as a
-  markdown block (NAMS REST drops free-form attributes). Relationships,
-  preferences, and facts are unsupported by the NAMS write API and are
-  logged-and-skipped. Documents are stored as ``role="document"`` messages.
-  Decision traces use the reasoning REST API.
+  markdown block (NAMS REST drops free-form attributes). Connector
+  relationships are encoded into the source entity description as a fenced
+  ``ccg-edges`` YAML block — when neo4j-agent-memory exposes
+  ``add_relationship`` against the NAMS REST API a one-shot migration can
+  drain those blocks into native edges. Documents are dual-tracked:
+  ``add_entity(Document, ...)`` for the queryable long-term node AND
+  ``short_term.add_message(role="document")`` to feed the NAMS extractor.
+  Entity records whose connector declares a ``BODY_FIELDS`` mapping also
+  have their body field sent through ``add_message`` for the same reason.
+  Decision traces go through the reasoning REST API unchanged.
 
 * **Bolt** (self-hosted) — full Cypher ingest. Entities via
   ``MemoryClient.long_term.add_entity`` with attributes, relationships via
-  direct Cypher MERGE, documents and decision traces likewise.
+  direct Cypher MERGE (native edges, no ccg-edges encoding), documents and
+  decision traces likewise. The two backends produce structurally different
+  graphs by design; the NAMS shape converges with bolt once
+  ``add_relationship`` is available upstream.
 """
 
 from __future__ import annotations
@@ -107,8 +116,245 @@ def _get_pole_type(label: str, ontology: DomainOntology) -> str:
 
 
 # ---------------------------------------------------------------------------
-# NAMS branch — best-effort B-partial port
+# NAMS shared primitives — also used by the generated import_data.py.j2.
+# A contract test (test_nams_ingest_parity.py) pins the call sequence so the
+# two consumers don't drift; if you change behavior here, mirror it in the
+# template and update the snapshot.
 # ---------------------------------------------------------------------------
+
+
+# Marker for the fenced YAML block we inject into entity descriptions to
+# carry connector-emitted relationships. NAMS REST has no ``add_relationship``
+# today, so edges live inside the source entity's ``description`` field; a
+# future migration parses these blocks and replays them as native edges.
+CCG_EDGES_OPEN = "```ccg-edges"
+CCG_EDGES_CLOSE = "```"
+
+
+def _build_ccg_edges_block(
+    relationships: list[dict[str, Any]], source_name: str
+) -> str:
+    """Build a fenced ``ccg-edges`` block listing this entity's outbound edges.
+
+    Returns empty string when ``source_name`` has no outbound edges. The block
+    is deterministic (sorted by type then target) so contract tests can diff
+    snapshots stably.
+    """
+    out: list[dict[str, str]] = []
+    for rel in relationships:
+        if rel.get("source_name") != source_name:
+            continue
+        out.append({
+            "type": rel.get("type", ""),
+            "target": rel.get("target_name", ""),
+            "target_label": rel.get("target_label", ""),
+        })
+    if not out:
+        return ""
+    out.sort(key=lambda e: (e["type"], e["target"]))
+    lines = [CCG_EDGES_OPEN]
+    for edge in out:
+        lines.append(f"- type: {edge['type']}")
+        lines.append(f"  target: {edge['target']}")
+        if edge["target_label"]:
+            lines.append(f"  target_label: {edge['target_label']}")
+    lines.append(CCG_EDGES_CLOSE)
+    return "\n".join(lines)
+
+
+def _description_with_edges(
+    base_description: str,
+    relationships: list[dict[str, Any]],
+    source_name: str,
+) -> str:
+    """Append the ccg-edges block (if any) to ``base_description``."""
+    block = _build_ccg_edges_block(relationships, source_name)
+    if not block:
+        return base_description
+    return f"{base_description}\n\n{block}"
+
+
+def _resolve_body(
+    item: dict[str, Any], label: str, body_fields: dict[str, str]
+) -> str | None:
+    """Return the body text for an entity record, or None if it has no body.
+
+    The connector declares ``BODY_FIELDS = {label: property_name}``. We look
+    up the property; if it's a non-empty string, it's the body. Anything else
+    (missing, empty, non-string) means this record skips the add_message
+    channel.
+    """
+    field = body_fields.get(label)
+    if not field:
+        return None
+    value = item.get(field)
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    return value
+
+
+# ---------------------------------------------------------------------------
+# NAMS branch — typed entities + ccg-edges + dual-tracked documents
+# ---------------------------------------------------------------------------
+
+
+async def run_nams_ingest(
+    client: Any,
+    fixture_data: dict,
+    ontology: DomainOntology,
+    body_fields: dict[str, str] | None = None,
+    on_event: Any = None,
+) -> dict[str, int]:
+    """Execute the NAMS write plan against an already-open MemoryClient.
+
+    Exposed separately from ``_ingest_with_nams`` (which owns the client
+    lifecycle and Rich progress UI) so the contract test and the scaffolded
+    ``import_data.py`` can drive the same sequence against their own client.
+
+    ``body_fields`` is the merged ``BODY_FIELDS`` from every active
+    connector ({label: property_name}). ``on_event`` is an optional callable
+    taking (stage: str, payload: dict) for progress reporting; pass None to
+    silence.
+    """
+    body_fields = body_fields or {}
+    domain_id = ontology.domain.id
+    relationships = fixture_data.get("relationships", [])
+    counts = {
+        "entities": 0,
+        "documents": 0,
+        "bodies": 0,
+        "traces": 0,
+        "edges_encoded": 0,
+        "failures": 0,
+    }
+    failures: list[dict[str, Any]] = []
+
+    def _emit(stage: str, **payload: Any) -> None:
+        if on_event is not None:
+            on_event(stage, payload)
+
+    # Stage 1: entities with ccg-edges encoded into description.
+    entities = fixture_data.get("entities", {})
+    for label, items in entities.items():
+        pole_type = _get_pole_type(label, ontology)
+        body_field = body_fields.get(label)
+        for item in items:
+            name = item.get("name") or f"{label}-{counts['entities']}"
+            base = _serialize_entity_to_description(item, label, pole_type)
+            description = _description_with_edges(base, relationships, name)
+            if description is not base:
+                counts["edges_encoded"] += 1
+            try:
+                await client.long_term.add_entity(
+                    name=name,
+                    entity_type=pole_type,
+                    description=description,
+                )
+                counts["entities"] += 1
+            except Exception as exc:  # noqa: BLE001 — surface to deadletter
+                failures.append({"kind": "entity", "name": name, "error": str(exc)})
+                counts["failures"] += 1
+                continue
+
+            # Hybrid: if this entity carries a body, feed it through
+            # short_term.add_message so NAMS extracts secondary structure.
+            if body_field is None:
+                continue
+            body = _resolve_body(item, label, body_fields)
+            if body is None:
+                continue
+            try:
+                await client.short_term.add_message(
+                    session_id=f"bodies-{domain_id}",
+                    role="document",
+                    content=body,
+                    metadata={
+                        "entity_name": name,
+                        "entity_label": label,
+                        "domain": domain_id,
+                    },
+                )
+                counts["bodies"] += 1
+            except Exception as exc:  # noqa: BLE001
+                failures.append({"kind": "body", "name": name, "error": str(exc)})
+                counts["failures"] += 1
+    _emit("entities", count=counts["entities"], edges=counts["edges_encoded"])
+
+    # Stage 2: documents — dual-tracked (long_term entity + short_term message).
+    # Document MENTIONS edges to mentioned entities live in the same ccg-edges
+    # YAML block as everything else; the document's outbound edges are
+    # discovered via relationships[].source_name == document title.
+    documents = fixture_data.get("documents", [])
+    doc_session = f"docs-{domain_id}"
+    for doc in documents:
+        title = doc.get("title", "")
+        if not title:
+            counts["failures"] += 1
+            failures.append({"kind": "document", "error": "missing title"})
+            continue
+        content = doc.get("content", "")
+        doc_base = (
+            f"{content}\n\n_pole_type: OBJECT_"
+            if content
+            else f"Document: {title}\n\n_pole_type: OBJECT_"
+        )
+        doc_description = _description_with_edges(doc_base, relationships, title)
+        try:
+            await client.long_term.add_entity(
+                name=title,
+                entity_type="OBJECT",
+                description=doc_description,
+            )
+            await client.short_term.add_message(
+                session_id=doc_session,
+                role="document",
+                content=content,
+                metadata={
+                    "title": title,
+                    "template_id": doc.get("template_id", ""),
+                    "template_name": doc.get("template_name", ""),
+                    "domain": domain_id,
+                },
+            )
+            counts["documents"] += 1
+        except Exception as exc:  # noqa: BLE001
+            failures.append({"kind": "document", "name": title, "error": str(exc)})
+            counts["failures"] += 1
+    _emit("documents", count=counts["documents"])
+
+    # Stage 3: decision traces via reasoning API (unchanged).
+    traces = fixture_data.get("traces", [])
+    trace_session = f"traces-{domain_id}"
+    for trace_data in traces:
+        try:
+            trace = await client.reasoning.start_trace(
+                session_id=trace_session,
+                task=trace_data.get("task", ""),
+            )
+            trace_id = getattr(trace, "id", None) or trace_data.get("id", "")
+            for step in trace_data.get("steps", []):
+                await client.reasoning.add_step(
+                    trace_id=trace_id,
+                    thought=step.get("thought", ""),
+                    action=step.get("action", ""),
+                    observation=step.get("observation", ""),
+                )
+            await client.reasoning.complete_trace(
+                trace_id=trace_id,
+                outcome=trace_data.get("outcome", ""),
+                success=True,
+            )
+            counts["traces"] += 1
+        except Exception as exc:  # noqa: BLE001
+            failures.append({"kind": "trace", "id": trace_data.get("id", ""), "error": str(exc)})
+            counts["failures"] += 1
+    _emit("traces", count=counts["traces"])
+
+    counts["failure_records"] = failures  # type: ignore[assignment]
+    return counts
 
 
 async def _ingest_with_nams(
@@ -116,15 +362,12 @@ async def _ingest_with_nams(
     ontology: DomainOntology,
     api_key: str,
     endpoint: str,
+    body_fields: dict[str, str] | None = None,
 ) -> None:
     """Ingest fixture data through the NAMS REST client.
 
-    Limits:
-      * Entity attributes other than ``description`` are not persisted by NAMS
-        REST — we serialize them into the description field as markdown.
-      * Relationships, preferences, and facts are unsupported. We log a single
-        aggregated warning per category.
-      * Schema DDL is owned by NAMS; we skip ``cypher/schema.cypher``.
+    Wraps :func:`run_nams_ingest` with client lifecycle + Rich progress. See
+    that function's docstring for the per-stage semantics.
     """
     from neo4j_agent_memory import MemoryClient, MemorySettings, NamsConfig
     from pydantic import SecretStr
@@ -140,101 +383,45 @@ async def _ingest_with_nams(
             TextColumn("[progress.description]{task.description}"),
             console=console,
         ) as progress:
+            console.print(
+                "  [dim][1/3] NAMS owns schema — skipping CREATE CONSTRAINT statements[/dim]"
+            )
+            task = progress.add_task("[2/3] Ingesting entities + documents (NAMS)...", total=None)
+            counts = await run_nams_ingest(
+                client=client,
+                fixture_data=fixture_data,
+                ontology=ontology,
+                body_fields=body_fields,
+            )
+            progress.update(
+                task,
+                description=(
+                    f"[2/3] Ingested {counts['entities']} entities "
+                    f"({counts['edges_encoded']} with ccg-edges), "
+                    f"{counts['documents']} documents, "
+                    f"{counts['bodies']} entity bodies"
+                ),
+            )
+            progress.update(
+                progress.add_task(
+                    f"[3/3] Ingested {counts['traces']} decision traces",
+                    total=None,
+                ),
+                completed=1,
+            )
 
-            # Step 1: skip schema (NAMS owns it)
-            console.print("  [dim][1/4] NAMS owns schema — skipping CREATE CONSTRAINT statements[/dim]")
-
-            # Step 2: entities
-            task = progress.add_task("[2/4] Ingesting entities (NAMS)...", total=None)
-            entity_count = 0
-            entities = fixture_data.get("entities", {})
-            for label, items in entities.items():
-                pole_type = _get_pole_type(label, ontology)
-                for item in items:
-                    name = item.get("name") or f"{label}-{entity_count}"
-                    description = _serialize_entity_to_description(item, label, pole_type)
-                    try:
-                        await client.long_term.add_entity(
-                            name=name,
-                            entity_type=pole_type,
-                            description=description,
-                        )
-                        entity_count += 1
-                    except Exception as e:
-                        console.print(f"  [yellow]Warning:[/yellow] Entity {name}: {e}")
-            progress.update(task, description=f"[2/4] Ingested {entity_count} entities")
-
-            # Step 2b: relationships — unsupported, log once
-            # TODO(nams-relationships): when neo4j-agent-memory exposes
-            # MemoryClient.add_relationship (tracking upstream), swap this
-            # console-note for the bolt path's ingest loop. Until then the
-            # docs in how-to/use-nams.md cover the bolt-first workaround.
-            rel_count = len(fixture_data.get("relationships", []))
-            if rel_count:
-                console.print(
-                    f"  [yellow]Note:[/yellow] {rel_count} relationships not "
-                    "persisted — NAMS write API does not yet support "
-                    "add_relationship. The graph will be disconnected; "
-                    "use --self-hosted for the full relationship-rich demo."
-                )
-
-            # Step 3: documents → messages with role="document"
-            task = progress.add_task("[3/4] Ingesting documents (as messages)...", total=None)
-            doc_count = 0
-            documents = fixture_data.get("documents", [])
-            doc_session = f"docs-{ontology.domain.id}"
-            for doc in documents:
-                try:
-                    await client.short_term.add_message(
-                        session_id=doc_session,
-                        role="document",
-                        content=doc.get("content", ""),
-                        metadata={
-                            "title": doc.get("title", ""),
-                            "template_id": doc.get("template_id", ""),
-                            "template_name": doc.get("template_name", ""),
-                            "domain": ontology.domain.id,
-                        },
-                    )
-                    doc_count += 1
-                except Exception as e:
-                    console.print(f"  [yellow]Warning:[/yellow] Document: {e}")
-            progress.update(task, description=f"[3/4] Ingested {doc_count} documents")
-
-            # Step 4: decision traces via reasoning API
-            task = progress.add_task("[4/4] Ingesting decision traces...", total=None)
-            trace_count = 0
-            traces = fixture_data.get("traces", [])
-            trace_session = f"traces-{ontology.domain.id}"
-            for trace_data in traces:
-                try:
-                    trace = await client.reasoning.start_trace(
-                        session_id=trace_session,
-                        task=trace_data.get("task", ""),
-                    )
-                    trace_id = getattr(trace, "id", None) or trace_data.get("id", "")
-                    for step in trace_data.get("steps", []):
-                        await client.reasoning.add_step(
-                            trace_id=trace_id,
-                            thought=step.get("thought", ""),
-                            action=step.get("action", ""),
-                            observation=step.get("observation", ""),
-                        )
-                    await client.reasoning.complete_trace(
-                        trace_id=trace_id,
-                        outcome=trace_data.get("outcome", ""),
-                        success=True,
-                    )
-                    trace_count += 1
-                except Exception as e:
-                    console.print(f"  [yellow]Warning:[/yellow] Trace: {e}")
-            progress.update(task, description=f"[4/4] Ingested {trace_count} decision traces")
-
+    rel_total = len(fixture_data.get("relationships", []))
     console.print(
-        f"\n  [green]NAMS ingestion complete:[/green] {entity_count} entities, "
-        f"{doc_count} documents, {trace_count} traces "
-        f"([dim]{rel_count} relationships skipped[/dim])"
+        f"\n  [green]NAMS ingestion complete:[/green] {counts['entities']} entities, "
+        f"{counts['documents']} documents, {counts['traces']} traces "
+        f"([dim]{rel_total} relationships encoded into "
+        f"{counts['edges_encoded']} entity descriptions as ccg-edges blocks; "
+        f"will migrate to native edges when NAMS add_relationship is available[/dim])"
     )
+    if counts["failures"]:
+        console.print(
+            f"  [yellow]{counts['failures']} record(s) failed — see logs for details.[/yellow]"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -637,8 +824,14 @@ def ingest_data(
     fixture_path: Path,
     ontology: DomainOntology,
     config: "ProjectConfig",
+    body_fields: dict[str, str] | None = None,
 ) -> None:
-    """Ingest fixture data into the configured memory backend."""
+    """Ingest fixture data into the configured memory backend.
+
+    ``body_fields`` is the union of every active connector's ``BODY_FIELDS``
+    map; the demo fixture path passes ``None``/``{}`` because pre-generated
+    fixtures don't carry connector-specific body conventions.
+    """
     if not fixture_path.exists():
         console.print(f"[red]Fixture file not found:[/red] {fixture_path}")
         return
@@ -656,7 +849,8 @@ def ingest_data(
             return
         asyncio.run(
             _ingest_with_nams(
-                fixture_data, ontology, config.nams_api_key, config.nams_endpoint
+                fixture_data, ontology, config.nams_api_key, config.nams_endpoint,
+                body_fields=body_fields,
             )
         )
         return

--- a/src/create_context_graph/ingest.py
+++ b/src/create_context_graph/ingest.py
@@ -250,8 +250,8 @@ async def run_nams_ingest(
     for label, items in entities.items():
         pole_type = _get_pole_type(label, ontology)
         body_field = body_fields.get(label)
-        for item in items:
-            name = item.get("name") or f"{label}-{counts['entities']}"
+        for entity_index, item in enumerate(items):
+            name = item.get("name") or f"{label}-{entity_index}"
             base = _serialize_entity_to_description(item, label, pole_type)
             description = _description_with_edges(base, relationships, name)
             if description is not base:

--- a/src/create_context_graph/templates/backend/connectors/claude_code_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/claude_code_connector.py.j2
@@ -129,6 +129,7 @@ class ClaudeCodeConnector:
 
     service_name = "Claude Code"
     service_description = "Import AI coding session history from local Claude Code JSONL files"
+    BODY_FIELDS = {"Message": "content"}
 
     def __init__(self) -> None:
         self._base_path: Path | None = None

--- a/src/create_context_graph/templates/backend/connectors/google_workspace_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/google_workspace_connector.py.j2
@@ -52,6 +52,8 @@ DRIVE_URL_PATTERN = re.compile(
 class GoogleWorkspaceConnector:
     """Import Drive files, comment threads, revisions, activity, calendar, and Gmail."""
 
+    BODY_FIELDS = {"DecisionThread": "content", "Reply": "content"}
+
     def __init__(self):
         self._access_token: str = ""
         self._folder_id: str = ""

--- a/src/create_context_graph/templates/backend/connectors/import_data.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/import_data.py.j2
@@ -705,6 +705,8 @@ def _retry_deadletter() -> int:
             body_field = rec.get("body_field")
             if body_field:
                 body_fields[rec["label"]] = body_field
+        else:
+            logger.warning("Skipping unsupported deadletter record kind during retry: %r", kind)
 
     # Move the old file aside; if retry fails, write a fresh deadletter.
     archive = DEADLETTER_FILE.with_suffix(".jsonl.retrying")

--- a/src/create_context_graph/templates/backend/connectors/import_data.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/import_data.py.j2
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -117,6 +118,7 @@ def _now_utc_iso() -> str:
 CCG_EDGES_OPEN = "```ccg-edges"
 CCG_EDGES_CLOSE = "```"
 _RESERVED_DESCRIPTION_KEYS = {"name", "description", "domain", "id", "uuid"}
+_SAFE_CYPHER_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _format_attribute(key: str, value: Any) -> str | None:
@@ -203,6 +205,12 @@ def _resolve_body(item: dict[str, Any], label: str, body_fields: dict[str, str])
     return value if value.strip() else None
 
 
+def _require_safe_cypher_identifier(value: str, kind: str) -> str:
+    if isinstance(value, str) and _SAFE_CYPHER_IDENTIFIER_RE.fullmatch(value):
+        return value
+    raise ValueError(f"Unsafe Cypher {kind}: {value!r}")
+
+
 async def _ingest_via_nams(data: dict[str, Any], body_fields: dict[str, str]) -> dict[str, int]:
     """Write data into NAMS. Mirrors src/create_context_graph/ingest.py
     run_nams_ingest() — kept in lockstep via test_nams_ingest_parity.py."""
@@ -262,6 +270,7 @@ async def _ingest_via_nams(data: dict[str, Any], body_fields: dict[str, str]) ->
                     _append_deadletter({
                         "ts": _now_utc_iso(), "kind": "body",
                         "label": label, "name": name, "error": str(exc),
+                        "item": item, "body_field": body_fields.get(label, ""),
                     })
 
         # Documents — dual-tracked
@@ -296,7 +305,7 @@ async def _ingest_via_nams(data: dict[str, Any], body_fields: dict[str, str]) ->
                 counts["failures"] += 1
                 _append_deadletter({
                     "ts": _now_utc_iso(), "kind": "document",
-                    "title": title, "error": str(exc),
+                    "title": title, "error": str(exc), "doc": doc,
                 })
 
         # Decision traces
@@ -321,7 +330,7 @@ async def _ingest_via_nams(data: dict[str, Any], body_fields: dict[str, str]) ->
                 counts["failures"] += 1
                 _append_deadletter({
                     "ts": _now_utc_iso(), "kind": "trace",
-                    "id": trace.get("id", ""), "error": str(exc),
+                    "id": trace.get("id", ""), "error": str(exc), "trace": trace,
                 })
 
     return counts
@@ -345,6 +354,15 @@ def _ingest_via_bolt(data: dict[str, Any], body_fields: dict[str, str]) -> dict[
         for label, items in data.get("entities", {}).items():
             if not items:
                 continue
+            try:
+                safe_label = _require_safe_cypher_identifier(label, "label")
+            except ValueError as exc:
+                counts["failures"] += 1
+                _append_deadletter({
+                    "ts": _now_utc_iso(), "kind": "entity-batch",
+                    "label": label, "error": str(exc), "items": items,
+                })
+                continue
             all_keys: set[str] = set()
             for item in items:
                 all_keys.update(item.keys())
@@ -364,18 +382,20 @@ def _ingest_via_bolt(data: dict[str, Any], body_fields: dict[str, str]) -> dict[
                 safe_items.append(safe)
             set_clause = ", ".join(f"n.{k} = item.{k}" for k in all_keys)
             cypher = (
-                f"UNWIND $batch AS item MERGE (n:{label} {{name: item.name}}) "
+                f"UNWIND $batch AS item MERGE (n:{safe_label} {{name: item.name}}) "
                 f"ON CREATE SET {set_clause} ON MATCH SET {set_clause}"
             )
             for i in range(0, len(safe_items), 500):
+                batch = safe_items[i:i + 500]
                 try:
-                    session.run(cypher, batch=safe_items[i:i + 500])
-                    counts["entities"] += len(safe_items[i:i + 500])
+                    session.run(cypher, batch=batch)
+                    counts["entities"] += len(batch)
                 except Exception as exc:  # noqa: BLE001
                     counts["failures"] += 1
                     _append_deadletter({
                         "ts": _now_utc_iso(), "kind": "entity-batch",
                         "label": label, "error": str(exc),
+                        "items": batch,
                     })
 
         # Relationships — native edges
@@ -383,10 +403,19 @@ def _ingest_via_bolt(data: dict[str, Any], body_fields: dict[str, str]) -> dict[
             rel_type = rel.get("type", "")
             if not rel_type:
                 continue
+            try:
+                safe_rel_type = _require_safe_cypher_identifier(rel_type, "relationship type")
+            except ValueError as exc:
+                counts["failures"] += 1
+                _append_deadletter({
+                    "ts": _now_utc_iso(), "kind": "relationship",
+                    "type": rel_type, "error": str(exc), "rel": rel,
+                })
+                continue
             cypher = (
                 f"MATCH (a {{name: $source_name}}) "
                 f"MATCH (b {{name: $target_name}}) "
-                f"MERGE (a)-[r:{rel_type}]->(b)"
+                f"MERGE (a)-[r:{safe_rel_type}]->(b)"
             )
             try:
                 session.run(cypher, {
@@ -398,7 +427,7 @@ def _ingest_via_bolt(data: dict[str, Any], body_fields: dict[str, str]) -> dict[
                 counts["failures"] += 1
                 _append_deadletter({
                     "ts": _now_utc_iso(), "kind": "relationship",
-                    "type": rel_type, "error": str(exc),
+                    "type": rel_type, "error": str(exc), "rel": rel,
                 })
 
         # Documents
@@ -420,7 +449,7 @@ def _ingest_via_bolt(data: dict[str, Any], body_fields: dict[str, str]) -> dict[
                 counts["failures"] += 1
                 _append_deadletter({
                     "ts": _now_utc_iso(), "kind": "document",
-                    "title": doc.get("title", ""), "error": str(exc),
+                    "title": doc.get("title", ""), "error": str(exc), "doc": doc,
                 })
 
         # Decision traces
@@ -454,7 +483,7 @@ def _ingest_via_bolt(data: dict[str, Any], body_fields: dict[str, str]) -> dict[
                 counts["failures"] += 1
                 _append_deadletter({
                     "ts": _now_utc_iso(), "kind": "trace",
-                    "id": trace.get("id", ""), "error": str(exc),
+                    "id": trace.get("id", ""), "error": str(exc), "trace": trace,
                 })
 
     return counts
@@ -663,11 +692,19 @@ def _retry_deadletter() -> int:
         kind = rec.get("kind")
         if kind == "entity" and "item" in rec:
             payload["entities"].setdefault(rec["label"], []).append(rec["item"])
+        elif kind == "entity-batch" and "items" in rec:
+            payload["entities"].setdefault(rec["label"], []).extend(rec["items"])
+        elif kind == "relationship" and "rel" in rec:
+            payload["relationships"].append(rec["rel"])
         elif kind == "document" and "doc" in rec:
             payload["documents"].append(rec["doc"])
         elif kind == "trace" and "trace" in rec:
             payload["traces"].append(rec["trace"])
-        # body / batch failures are skipped — they re-derive from entity retries
+        elif kind == "body" and "item" in rec:
+            payload["entities"].setdefault(rec["label"], []).append(rec["item"])
+            body_field = rec.get("body_field")
+            if body_field:
+                body_fields[rec["label"]] = body_field
 
     # Move the old file aside; if retry fails, write a fresh deadletter.
     archive = DEADLETTER_FILE.with_suffix(".jsonl.retrying")

--- a/src/create_context_graph/templates/backend/connectors/import_data.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/import_data.py.j2
@@ -405,6 +405,16 @@ def _ingest_via_bolt(data: dict[str, Any], body_fields: dict[str, str]) -> dict[
                 continue
             try:
                 safe_rel_type = _require_safe_cypher_identifier(rel_type, "relationship type")
+                source_label = rel.get("source_label", "")
+                target_label = rel.get("target_label", "")
+                source_pattern = "a"
+                target_pattern = "b"
+                if source_label:
+                    safe_source_label = _require_safe_cypher_identifier(source_label, "source label")
+                    source_pattern = f"a:{safe_source_label}"
+                if target_label:
+                    safe_target_label = _require_safe_cypher_identifier(target_label, "target label")
+                    target_pattern = f"b:{safe_target_label}"
             except ValueError as exc:
                 counts["failures"] += 1
                 _append_deadletter({
@@ -413,8 +423,8 @@ def _ingest_via_bolt(data: dict[str, Any], body_fields: dict[str, str]) -> dict[
                 })
                 continue
             cypher = (
-                f"MATCH (a {{name: $source_name}}) "
-                f"MATCH (b {{name: $target_name}}) "
+                f"MATCH ({source_pattern} {{name: $source_name}}) "
+                f"MATCH ({target_pattern} {{name: $target_name}}) "
                 f"MERGE (a)-[r:{safe_rel_type}]->(b)"
             )
             try:

--- a/src/create_context_graph/templates/backend/connectors/import_data.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/import_data.py.j2
@@ -1,15 +1,47 @@
-{% raw %}"""Data import script — fetches data from connected SaaS services.
+{% raw %}"""Data import script — fetch from connected SaaS services and write into
+the configured memory backend (NAMS or self-hosted bolt Neo4j).
 
 Usage:
-    python scripts/import_data.py
-    python scripts/import_data.py --ingest  # Also ingest into Neo4j
+    python scripts/import_data.py              # fetch + ingest (idempotent)
+    python scripts/import_data.py --dry-run    # fetch only, write fixtures.json
+    python scripts/import_data.py --retry      # drain .context-graph/deadletter.jsonl
+
+Idempotency strategy:
+    * Each connector tracks an ``updated_after`` watermark in
+      ``.context-graph/watermarks.json`` so re-runs only fetch deltas.
+    * NAMS ``add_entity`` is trusted to merge by ``name``.
+    * Failures (one record at a time) are appended to
+      ``.context-graph/deadletter.jsonl`` and the watermark only advances on a
+      clean run; ``--retry`` drains the deadletter into the same write path.
+
+NAMS write shape:
+    * Entities → ``long_term.add_entity`` with attributes markdown-serialized
+      into ``description``. Outbound relationships from each entity are
+      encoded into the same description as a fenced ``ccg-edges`` YAML block
+      (NAMS REST has no add_relationship today; the block migrates cleanly
+      when it does).
+    * Documents → dual-tracked: ``add_entity(name=title, type=OBJECT)`` AND
+      ``short_term.add_message(role="document")`` so the NAMS extractor sees
+      the prose.
+    * Entity records with a body field (declared per-connector via
+      ``BODY_FIELDS = {label: property}``) also flow through ``add_message``.
+    * Decision traces use the reasoning REST API.
+
+This file is duplicated from ``src/create_context_graph/ingest.py``'s
+``run_nams_ingest`` by design (see the create-context-graph CLAUDE.md
+discussion). The contract test ``test_nams_ingest_parity.py`` pins their call
+sequences against a shared fixture.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 {% endraw %}{% for conn in saas_connectors %}{% if conn == 'github' %}{% raw %}
 from app.connectors.github_connector import GitHubConnector
@@ -31,29 +63,428 @@ from app.connectors.linear_connector import LinearConnector
 from app.connectors.google_workspace_connector import GoogleWorkspaceConnector
 {% endraw %}{% elif conn == 'claude-code' %}{% raw %}
 from app.connectors.claude_code_connector import ClaudeCodeConnector
-{% endraw %}{% endif %}{% endfor %}
-{% raw %}
+{% endraw %}{% elif conn == 'local-file' %}{% raw %}
+from app.connectors.local_file_connector import LocalFileConnector
+{% endraw %}{% endif %}{% endfor %}{% raw %}
+
 from app.config import settings
 
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
-def main():
-    """Run all configured connectors and write results to fixtures.json."""
-    ingest = "--ingest" in sys.argv
-    data_dir = Path(__file__).parent.parent.parent / "data"
-    fixture_path = data_dir / "fixtures.json"
 
-    all_entities: dict[str, list[dict]] = {}
-    all_relationships: list[dict] = []
-    all_documents: list[dict] = []
+# ---------------------------------------------------------------------------
+# Paths & sidecar files
+# ---------------------------------------------------------------------------
 
-    connectors = []
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+DATA_DIR = PROJECT_ROOT / "data"
+SIDECAR_DIR = PROJECT_ROOT / ".context-graph"
+WATERMARKS_FILE = SIDECAR_DIR / "watermarks.json"
+DEADLETTER_FILE = SIDECAR_DIR / "deadletter.jsonl"
+FIXTURES_FILE = DATA_DIR / "fixtures.json"
+
+
+def _load_watermarks() -> dict[str, str]:
+    if not WATERMARKS_FILE.exists():
+        return {}
+    try:
+        return json.loads(WATERMARKS_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        logger.warning("watermarks.json unreadable, treating as empty")
+        return {}
+
+
+def _save_watermarks(marks: dict[str, str]) -> None:
+    SIDECAR_DIR.mkdir(parents=True, exist_ok=True)
+    WATERMARKS_FILE.write_text(json.dumps(marks, indent=2, sort_keys=True))
+
+
+def _append_deadletter(record: dict[str, Any]) -> None:
+    SIDECAR_DIR.mkdir(parents=True, exist_ok=True)
+    with DEADLETTER_FILE.open("a") as f:
+        f.write(json.dumps(record, default=str) + "\n")
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# NAMS write helpers — mirror ingest.py run_nams_ingest()
+# ---------------------------------------------------------------------------
+
+CCG_EDGES_OPEN = "```ccg-edges"
+CCG_EDGES_CLOSE = "```"
+_RESERVED_DESCRIPTION_KEYS = {"name", "description", "domain", "id", "uuid"}
+
+
+def _format_attribute(key: str, value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (list, dict)):
+        value = json.dumps(value, default=str)
+    return f"**{key.replace('_', ' ').strip().capitalize()}**: {value}"
+
+
+def _serialize_entity_to_description(item: dict[str, Any], label: str, pole_type: str) -> str:
+    parts: list[str] = []
+    existing = (item.get("description") or "").strip()
+    parts.append(existing if existing else f"{label}.")
+    attr_lines: list[str] = []
+    for key, value in item.items():
+        if key in _RESERVED_DESCRIPTION_KEYS:
+            continue
+        line = _format_attribute(key, value)
+        if line:
+            attr_lines.append(line)
+    if attr_lines:
+        parts.append("")
+        parts.extend(attr_lines)
+    parts.append("")
+    parts.append(f"_pole_type: {pole_type}_")
+    return "\n".join(parts)
+
+
+def _build_ccg_edges_block(relationships: list[dict[str, Any]], source_name: str) -> str:
+    out: list[dict[str, str]] = []
+    for rel in relationships:
+        if rel.get("source_name") != source_name:
+            continue
+        out.append({
+            "type": rel.get("type", ""),
+            "target": rel.get("target_name", ""),
+            "target_label": rel.get("target_label", ""),
+        })
+    if not out:
+        return ""
+    out.sort(key=lambda e: (e["type"], e["target"]))
+    lines = [CCG_EDGES_OPEN]
+    for edge in out:
+        lines.append(f"- type: {edge['type']}")
+        lines.append(f"  target: {edge['target']}")
+        if edge["target_label"]:
+            lines.append(f"  target_label: {edge['target_label']}")
+    lines.append(CCG_EDGES_CLOSE)
+    return "\n".join(lines)
+
+
+def _description_with_edges(base: str, relationships: list[dict[str, Any]], source_name: str) -> str:
+    block = _build_ccg_edges_block(relationships, source_name)
+    return f"{base}\n\n{block}" if block else base
+
+
+def _pole_type_for_label(label: str) -> str:
+    """Best-effort POLE+O type from label heuristics — connectors are
+    free-form and don't always map cleanly to the ontology, so we fall back
+    to OBJECT for anything unrecognized."""
+    person_like = {"Person", "User", "Author", "Assignee", "Creator", "Reviewer"}
+    org_like = {"Organization", "Team", "Project", "Workspace", "Group"}
+    location_like = {"Location", "Folder", "Place"}
+    event_like = {"Event", "Meeting", "Cycle", "Activity"}
+    if label in person_like:
+        return "PERSON"
+    if label in org_like:
+        return "ORGANIZATION"
+    if label in location_like:
+        return "LOCATION"
+    if label in event_like:
+        return "EVENT"
+    return "OBJECT"
+
+
+def _resolve_body(item: dict[str, Any], label: str, body_fields: dict[str, str]) -> str | None:
+    field = body_fields.get(label)
+    if not field:
+        return None
+    value = item.get(field)
+    if not isinstance(value, str):
+        return None
+    return value if value.strip() else None
+
+
+async def _ingest_via_nams(data: dict[str, Any], body_fields: dict[str, str]) -> dict[str, int]:
+    """Write data into NAMS. Mirrors src/create_context_graph/ingest.py
+    run_nams_ingest() — kept in lockstep via test_nams_ingest_parity.py."""
+    from neo4j_agent_memory import MemoryClient, MemorySettings, NamsConfig
+    from pydantic import SecretStr
+
+    mem_settings = MemorySettings(
+        backend="nams",
+        nams=NamsConfig(
+            api_key=SecretStr(settings.memory_api_key),
+            endpoint=settings.memory_nams_endpoint or "https://memory.neo4jlabs.com/v1",
+        ),
+    )
+
+    relationships = data.get("relationships", [])
+    counts = {"entities": 0, "documents": 0, "bodies": 0, "traces": 0, "edges_encoded": 0, "failures": 0}
+
+    async with MemoryClient(mem_settings) as client:
+        # Entities + bodies
+        entities = data.get("entities", {})
+        ent_idx = 0
+        for label, items in entities.items():
+            pole_type = _pole_type_for_label(label)
+            for item in items:
+                name = item.get("name") or f"{label}-{ent_idx}"
+                ent_idx += 1
+                base = _serialize_entity_to_description(item, label, pole_type)
+                description = _description_with_edges(base, relationships, name)
+                if description is not base:
+                    counts["edges_encoded"] += 1
+                try:
+                    await client.long_term.add_entity(
+                        name=name, entity_type=pole_type, description=description,
+                    )
+                    counts["entities"] += 1
+                except Exception as exc:  # noqa: BLE001
+                    counts["failures"] += 1
+                    _append_deadletter({
+                        "ts": _now_utc_iso(), "kind": "entity",
+                        "label": label, "name": name, "error": str(exc), "item": item,
+                    })
+                    continue
+
+                body = _resolve_body(item, label, body_fields)
+                if body is None:
+                    continue
+                try:
+                    await client.short_term.add_message(
+                        session_id="bodies-import",
+                        role="document",
+                        content=body,
+                        metadata={"entity_name": name, "entity_label": label},
+                    )
+                    counts["bodies"] += 1
+                except Exception as exc:  # noqa: BLE001
+                    counts["failures"] += 1
+                    _append_deadletter({
+                        "ts": _now_utc_iso(), "kind": "body",
+                        "label": label, "name": name, "error": str(exc),
+                    })
+
+        # Documents — dual-tracked
+        for doc in data.get("documents", []):
+            title = doc.get("title", "")
+            if not title:
+                counts["failures"] += 1
+                _append_deadletter({"ts": _now_utc_iso(), "kind": "document", "error": "missing title", "doc": doc})
+                continue
+            content = doc.get("content", "")
+            base = (
+                f"{content}\n\n_pole_type: OBJECT_"
+                if content else f"Document: {title}\n\n_pole_type: OBJECT_"
+            )
+            description = _description_with_edges(base, relationships, title)
+            try:
+                await client.long_term.add_entity(
+                    name=title, entity_type="OBJECT", description=description,
+                )
+                await client.short_term.add_message(
+                    session_id="docs-import",
+                    role="document",
+                    content=content,
+                    metadata={
+                        "title": title,
+                        "template_id": doc.get("template_id", ""),
+                        "template_name": doc.get("template_name", ""),
+                    },
+                )
+                counts["documents"] += 1
+            except Exception as exc:  # noqa: BLE001
+                counts["failures"] += 1
+                _append_deadletter({
+                    "ts": _now_utc_iso(), "kind": "document",
+                    "title": title, "error": str(exc),
+                })
+
+        # Decision traces
+        for trace in data.get("traces", []):
+            try:
+                started = await client.reasoning.start_trace(
+                    session_id="traces-import", task=trace.get("task", ""),
+                )
+                trace_id = getattr(started, "id", None) or trace.get("id", "")
+                for step in trace.get("steps", []):
+                    await client.reasoning.add_step(
+                        trace_id=trace_id,
+                        thought=step.get("thought", ""),
+                        action=step.get("action", ""),
+                        observation=step.get("observation", ""),
+                    )
+                await client.reasoning.complete_trace(
+                    trace_id=trace_id, outcome=trace.get("outcome", ""), success=True,
+                )
+                counts["traces"] += 1
+            except Exception as exc:  # noqa: BLE001
+                counts["failures"] += 1
+                _append_deadletter({
+                    "ts": _now_utc_iso(), "kind": "trace",
+                    "id": trace.get("id", ""), "error": str(exc),
+                })
+
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Bolt write path — native edges via raw Cypher MERGE
+# ---------------------------------------------------------------------------
+
+
+def _ingest_via_bolt(data: dict[str, Any], body_fields: dict[str, str]) -> dict[str, int]:
+    """Write data into self-hosted Neo4j via Cypher MERGE. Native edges, no
+    ccg-edges encoding (the bolt graph IS the source of truth)."""
+    from app.context_graph_client import get_driver
+
+    counts = {"entities": 0, "documents": 0, "relationships": 0, "traces": 0, "failures": 0}
+    driver = get_driver()
+
+    with driver.session() as session:
+        # Entities — UNWIND batched by label
+        for label, items in data.get("entities", {}).items():
+            if not items:
+                continue
+            all_keys: set[str] = set()
+            for item in items:
+                all_keys.update(item.keys())
+            safe_items = []
+            for item in items:
+                safe: dict[str, Any] = {}
+                for k in all_keys:
+                    v = item.get(k)
+                    if isinstance(v, bool):
+                        safe[k] = v
+                    elif isinstance(v, (int, float, str)):
+                        safe[k] = v
+                    elif v is None:
+                        safe[k] = ""
+                    else:
+                        safe[k] = str(v)
+                safe_items.append(safe)
+            set_clause = ", ".join(f"n.{k} = item.{k}" for k in all_keys)
+            cypher = (
+                f"UNWIND $batch AS item MERGE (n:{label} {{name: item.name}}) "
+                f"ON CREATE SET {set_clause} ON MATCH SET {set_clause}"
+            )
+            for i in range(0, len(safe_items), 500):
+                try:
+                    session.run(cypher, batch=safe_items[i:i + 500])
+                    counts["entities"] += len(safe_items[i:i + 500])
+                except Exception as exc:  # noqa: BLE001
+                    counts["failures"] += 1
+                    _append_deadletter({
+                        "ts": _now_utc_iso(), "kind": "entity-batch",
+                        "label": label, "error": str(exc),
+                    })
+
+        # Relationships — native edges
+        for rel in data.get("relationships", []):
+            rel_type = rel.get("type", "")
+            if not rel_type:
+                continue
+            cypher = (
+                f"MATCH (a {{name: $source_name}}) "
+                f"MATCH (b {{name: $target_name}}) "
+                f"MERGE (a)-[r:{rel_type}]->(b)"
+            )
+            try:
+                session.run(cypher, {
+                    "source_name": rel.get("source_name", ""),
+                    "target_name": rel.get("target_name", ""),
+                })
+                counts["relationships"] += 1
+            except Exception as exc:  # noqa: BLE001
+                counts["failures"] += 1
+                _append_deadletter({
+                    "ts": _now_utc_iso(), "kind": "relationship",
+                    "type": rel_type, "error": str(exc),
+                })
+
+        # Documents
+        for doc in data.get("documents", []):
+            try:
+                session.run(
+                    "MERGE (d:Document {title: $title}) "
+                    "SET d.content = $content, d.template_id = $template_id, "
+                    "d.template_name = $template_name",
+                    {
+                        "title": doc.get("title", ""),
+                        "content": doc.get("content", ""),
+                        "template_id": doc.get("template_id", ""),
+                        "template_name": doc.get("template_name", ""),
+                    },
+                )
+                counts["documents"] += 1
+            except Exception as exc:  # noqa: BLE001
+                counts["failures"] += 1
+                _append_deadletter({
+                    "ts": _now_utc_iso(), "kind": "document",
+                    "title": doc.get("title", ""), "error": str(exc),
+                })
+
+        # Decision traces
+        for trace in data.get("traces", []):
+            try:
+                session.run(
+                    "MERGE (t:DecisionTrace {id: $id}) "
+                    "SET t.task = $task, t.outcome = $outcome",
+                    {
+                        "id": trace.get("id", ""),
+                        "task": trace.get("task", ""),
+                        "outcome": trace.get("outcome", ""),
+                    },
+                )
+                for i, step in enumerate(trace.get("steps", [])):
+                    session.run(
+                        "MATCH (t:DecisionTrace {id: $trace_id}) "
+                        "MERGE (s:TraceStep {trace_id: $trace_id, step_number: $step_number}) "
+                        "SET s.thought = $thought, s.action = $action, s.observation = $observation "
+                        "MERGE (t)-[:HAS_STEP]->(s)",
+                        {
+                            "trace_id": trace.get("id", ""),
+                            "step_number": i + 1,
+                            "thought": step.get("thought", ""),
+                            "action": step.get("action", ""),
+                            "observation": step.get("observation", ""),
+                        },
+                    )
+                counts["traces"] += 1
+            except Exception as exc:  # noqa: BLE001
+                counts["failures"] += 1
+                _append_deadletter({
+                    "ts": _now_utc_iso(), "kind": "trace",
+                    "id": trace.get("id", ""), "error": str(exc),
+                })
+
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Connector orchestration
+# ---------------------------------------------------------------------------
+
+
+def _normalized_to_dict(data: Any) -> dict[str, Any]:
+    """NormalizedData is a Pydantic model; older returns might already be dict.
+    Coerce to the dict shape the writers expect."""
+    if hasattr(data, "model_dump"):
+        return data.model_dump()
+    if hasattr(data, "dict"):
+        return data.dict()
+    return data
+
+
+def _build_connectors() -> list[tuple[str, Any, dict[str, Any], dict[str, Any]]]:
+    """Build (name, instance, credentials, fetch_kwargs) tuples for every
+    enabled connector with credentials present."""
+    out: list[tuple[str, Any, dict[str, Any], dict[str, Any]]] = []
 {% endraw %}
 {% for conn in saas_connectors %}
 {% if conn == 'github' %}{% raw %}
     if settings.github_token and settings.github_repo:
-        connectors.append(("GitHub", GitHubConnector(), {
-            "token": settings.github_token,
-            "repo": settings.github_repo,
+        out.append(("GitHub", GitHubConnector(), {
+            "token": settings.github_token, "repo": settings.github_repo,
         }, {
             "issues_limit": settings.github_issues_limit or settings.github_limit,
             "prs_limit": settings.github_prs_limit or settings.github_limit,
@@ -64,30 +495,25 @@ def main():
         }))
 {% endraw %}{% elif conn == 'notion' %}{% raw %}
     if settings.notion_token:
-        connectors.append(("Notion", NotionConnector(), {
-            "token": settings.notion_token,
-        }, {}))
+        out.append(("Notion", NotionConnector(), {"token": settings.notion_token}, {}))
 {% endraw %}{% elif conn == 'jira' %}{% raw %}
     if settings.jira_url and settings.jira_email and settings.jira_token:
-        connectors.append(("Jira", JiraConnector(), {
-            "url": settings.jira_url,
-            "email": settings.jira_email,
-            "token": settings.jira_token,
-            "project": settings.jira_project,
+        out.append(("Jira", JiraConnector(), {
+            "url": settings.jira_url, "email": settings.jira_email,
+            "token": settings.jira_token, "project": settings.jira_project,
         }, {}))
 {% endraw %}{% elif conn == 'slack' %}{% raw %}
     if settings.slack_token:
-        connectors.append(("Slack", SlackConnector(), {
-            "token": settings.slack_token,
-            "channels": settings.slack_channels or "all",
+        out.append(("Slack", SlackConnector(), {
+            "token": settings.slack_token, "channels": settings.slack_channels or "all",
         }, {}))
 {% endraw %}{% elif conn == 'gmail' %}{% raw %}
-    connectors.append(("Gmail", GmailConnector(), {}, {}))
+    out.append(("Gmail", GmailConnector(), {}, {}))
 {% endraw %}{% elif conn == 'gcal' %}{% raw %}
-    connectors.append(("Google Calendar", GCalConnector(), {}, {}))
+    out.append(("Google Calendar", GCalConnector(), {}, {}))
 {% endraw %}{% elif conn == 'salesforce' %}{% raw %}
     if settings.salesforce_username and settings.salesforce_password:
-        connectors.append(("Salesforce", SalesforceConnector(), {
+        out.append(("Salesforce", SalesforceConnector(), {
             "username": settings.salesforce_username,
             "password": settings.salesforce_password,
             "security_token": settings.salesforce_security_token or "",
@@ -95,93 +521,173 @@ def main():
         }, {}))
 {% endraw %}{% elif conn == 'linear' %}{% raw %}
     if settings.linear_api_key:
-        connectors.append(("Linear", LinearConnector(), {
+        out.append(("Linear", LinearConnector(), {
             "api_key": settings.linear_api_key,
             "team_key": settings.linear_team or "",
         }, {}))
 {% endraw %}{% elif conn == 'google-workspace' %}{% raw %}
-    connectors.append(("Google Workspace", GoogleWorkspaceConnector(), {
+    out.append(("Google Workspace", GoogleWorkspaceConnector(), {
         "client_id": settings.google_client_id or "",
         "client_secret": settings.google_client_secret or "",
         "folder_id": settings.gws_folder_id or "",
     }, {}))
 {% endraw %}{% elif conn == 'claude-code' %}{% raw %}
-    connectors.append(("Claude Code", ClaudeCodeConnector(), {
+    out.append(("Claude Code", ClaudeCodeConnector(), {
         "scope": settings.claude_code_scope,
         "since": settings.claude_code_since or None,
         "max_sessions": settings.claude_code_max_sessions or None,
         "content_mode": settings.claude_code_content_mode or None,
         "base_path": settings.claude_code_base_path or None,
     }, {}))
+{% endraw %}{% elif conn == 'local-file' %}{% raw %}
+    out.append(("Local File", LocalFileConnector(), {}, {}))
 {% endraw %}{% endif %}
 {% endfor %}
 {% raw %}
-    failed = 0
-    for name, connector, creds, fetch_kwargs in connectors:
+    return out
+
+
+def _watermark_key(connector_name: str) -> str:
+    return connector_name.lower().replace(" ", "-")
+
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv
+    retry = "--retry" in sys.argv
+
+    if retry:
+        return _retry_deadletter()
+
+    watermarks = _load_watermarks()
+    connector_specs = _build_connectors()
+
+    if not connector_specs:
+        print("No connectors enabled or no credentials present.", file=sys.stderr)
+        return 1
+
+    aggregated: dict[str, Any] = {"entities": {}, "relationships": [], "documents": [], "traces": []}
+    body_fields: dict[str, str] = {}
+    advanced_watermarks: dict[str, str] = {}
+    any_failure = False
+
+    for name, connector, creds, fetch_kwargs in connector_specs:
         try:
             print(f"Connecting to {name}...")
             connector.authenticate(creds)
-            print(f"Fetching data from {name}...")
-            data = connector.fetch(**fetch_kwargs)
+            kw = dict(fetch_kwargs)
+            wm = watermarks.get(_watermark_key(name))
+            if wm:
+                kw.setdefault("updated_after", wm)
+            print(f"Fetching from {name} (watermark={wm or 'none'})...")
+            data = _normalized_to_dict(connector.fetch(**kw))
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ! {name}: {exc}", file=sys.stderr)
+            any_failure = True
+            continue
 
-            for label, items in data["entities"].items():
-                all_entities.setdefault(label, []).extend(items)
-            all_relationships.extend(data["relationships"])
-            all_documents.extend(data["documents"])
+        for label, items in data.get("entities", {}).items():
+            aggregated["entities"].setdefault(label, []).extend(items)
+        aggregated["relationships"].extend(data.get("relationships", []))
+        aggregated["documents"].extend(data.get("documents", []))
+        aggregated["traces"].extend(data.get("traces", []))
 
-            entity_count = sum(len(v) for v in data["entities"].values())
-            print(f"  + {name}: {entity_count} entities, {len(data['documents'])} documents")
-        except Exception as e:
-            print(f"  ! {name}: {e}", file=sys.stderr)
-            failed += 1
+        for label, field in getattr(connector, "BODY_FIELDS", {}).items():
+            body_fields[label] = field
 
-    if not all_entities and not all_relationships:
-        print("\nNo data collected. fixtures.json not modified.", file=sys.stderr)
-        sys.exit(1)
+        # Tentative watermark advance — only committed if the whole import
+        # batch lands cleanly.
+        advanced_watermarks[_watermark_key(name)] = _now_utc_iso()
 
-    # Write results
-    result = {
-        "entities": all_entities,
-        "relationships": all_relationships,
-        "documents": all_documents,
-    }
-    fixture_path.parent.mkdir(parents=True, exist_ok=True)
-    fixture_path.write_text(json.dumps(result, indent=2, default=str))
-    print(f"\nImported data written to {fixture_path}")
+        ent_count = sum(len(v) for v in data.get("entities", {}).values())
+        print(f"  + {name}: {ent_count} entities, {len(data.get('documents', []))} documents")
 
-    if ingest:
-        print("\nIngesting into Neo4j...")
-        from app.context_graph_client import get_driver
+    # Persist the fetched payload as fixtures.json regardless of ingest mode.
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    FIXTURES_FILE.write_text(json.dumps(aggregated, indent=2, default=str))
+    print(f"\nWrote {FIXTURES_FILE}")
 
-        driver = get_driver()
-        with driver.session() as session:
-            for label, items in all_entities.items():
-                if not items:
-                    continue
-                all_keys = set()
-                for item in items:
-                    all_keys.update(item.keys())
-                safe_items = []
-                for item in items:
-                    safe = {}
-                    for k in all_keys:
-                        v = item.get(k)
-                        if isinstance(v, bool):
-                            safe[k] = v
-                        elif isinstance(v, (int, float, str)):
-                            safe[k] = v
-                        elif v is None:
-                            safe[k] = ""
-                        else:
-                            safe[k] = str(v)
-                    safe_items.append(safe)
-                set_clause = ", ".join(f"n.{k} = item.{k}" for k in all_keys)
-                cypher = f"UNWIND $batch AS item MERGE (n:{label} {{name: item.name}}) ON CREATE SET {set_clause} ON MATCH SET {set_clause}"
-                for i in range(0, len(safe_items), 500):
-                    session.run(cypher, batch=safe_items[i:i + 500])
-            print(f"  + Ingested {sum(len(v) for v in all_entities.values())} entities")
+    if dry_run:
+        print("Dry-run: skipping ingest.")
+        return 0 if not any_failure else 2
+
+    print(f"\nIngesting into {settings.memory_backend}...")
+    if settings.memory_backend == "nams":
+        counts = asyncio.run(_ingest_via_nams(aggregated, body_fields))
+    else:
+        counts = _ingest_via_bolt(aggregated, body_fields)
+
+    print(f"  Ingest counts: {counts}")
+    if counts.get("failures"):
+        print(
+            f"  {counts['failures']} record(s) failed — appended to {DEADLETTER_FILE}. "
+            f"Re-run with --retry to drain.",
+            file=sys.stderr,
+        )
+        any_failure = True
+
+    # Only advance watermarks on a clean run; otherwise the user keeps the
+    # ability to re-fetch the same window.
+    if not any_failure:
+        watermarks.update(advanced_watermarks)
+        _save_watermarks(watermarks)
+        print(f"Watermarks advanced: {list(advanced_watermarks)}")
+
+    return 0 if not any_failure else 2
+
+
+def _retry_deadletter() -> int:
+    """Re-attempt every line in deadletter.jsonl, removing the file on success."""
+    if not DEADLETTER_FILE.exists():
+        print("No deadletter file — nothing to retry.")
+        return 0
+
+    pending: list[dict[str, Any]] = []
+    for line in DEADLETTER_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            pending.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    if not pending:
+        DEADLETTER_FILE.unlink()
+        return 0
+
+    # Rebuild a minimal NormalizedData payload from deadletter records that
+    # carry enough info to retry. Entity bodies live in the original item.
+    payload: dict[str, Any] = {"entities": {}, "relationships": [], "documents": [], "traces": []}
+    body_fields: dict[str, str] = {}
+    for rec in pending:
+        kind = rec.get("kind")
+        if kind == "entity" and "item" in rec:
+            payload["entities"].setdefault(rec["label"], []).append(rec["item"])
+        elif kind == "document" and "doc" in rec:
+            payload["documents"].append(rec["doc"])
+        elif kind == "trace" and "trace" in rec:
+            payload["traces"].append(rec["trace"])
+        # body / batch failures are skipped — they re-derive from entity retries
+
+    # Move the old file aside; if retry fails, write a fresh deadletter.
+    archive = DEADLETTER_FILE.with_suffix(".jsonl.retrying")
+    DEADLETTER_FILE.rename(archive)
+
+    if settings.memory_backend == "nams":
+        counts = asyncio.run(_ingest_via_nams(payload, body_fields))
+    else:
+        counts = _ingest_via_bolt(payload, body_fields)
+
+    if counts.get("failures"):
+        print(f"Retry left {counts['failures']} record(s) unresolved (new deadletter written).", file=sys.stderr)
+        archive.unlink(missing_ok=True)
+        return 2
+
+    archive.unlink(missing_ok=True)
+    print(f"Retry drained {len(pending)} record(s).")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())
 {% endraw %}

--- a/src/create_context_graph/templates/backend/connectors/linear_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/linear_connector.py.j2
@@ -98,6 +98,8 @@ def _describe_history_step(entry: dict) -> dict[str, str] | None:
 class LinearConnector:
     """Import issues, projects, cycles, and team data from Linear."""
 
+    BODY_FIELDS = {"Comment": "body"}
+
     def __init__(self):
         self._api_key: str = ""
         self._team_key: str = ""

--- a/src/create_context_graph/templates/backend/connectors/local_file_connector.py.j2
+++ b/src/create_context_graph/templates/backend/connectors/local_file_connector.py.j2
@@ -453,6 +453,7 @@ class LocalFileConnector:
         "formats."
     )
     requires_oauth = False
+    BODY_FIELDS = {"Document": "description", "Section": "description"}
 
     def __init__(self) -> None:
         self._paths: list[Path] = []

--- a/src/create_context_graph/templates/backend/shared/memory_adapter.py.j2
+++ b/src/create_context_graph/templates/backend/shared/memory_adapter.py.j2
@@ -231,6 +231,8 @@ def _document_record_from_entity(entity: Any) -> dict[str, Any] | None:
         content = content.split("```ccg-edges", 1)[0].rstrip()
     if "_pole_type:" in content:
         content = content.rsplit("_pole_type:", 1)[0].rstrip()
+    if not content.strip():
+        return None
     return {
         "title": name,
         "content": content,

--- a/src/create_context_graph/templates/backend/shared/memory_adapter.py.j2
+++ b/src/create_context_graph/templates/backend/shared/memory_adapter.py.j2
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 
 _RESERVED_DESCRIPTION_KEYS = {"name", "description", "domain", "id", "uuid"}
+CCG_EDGES_OPEN = "```ccg-edges"
+CCG_EDGES_CLOSE = "```"
 
 
 def _format_attribute(key: str, value: Any) -> str | None:
@@ -55,6 +57,41 @@ def _serialize_entity_to_description(item: dict[str, Any], label: str, pole_type
     return "\n".join(parts)
 
 
+def _build_ccg_edges_block(relationships: list[dict[str, Any]], source_name: str) -> str:
+    """Encode outbound edges from ``source_name`` as a fenced YAML block.
+
+    NAMS REST has no add_relationship today; the block embeds enough info
+    (type, target, target_label) for a future migration to read it back and
+    call add_relationship per entry. Deterministically sorted for stable
+    parity tests.
+    """
+    out: list[dict[str, str]] = []
+    for rel in relationships:
+        if rel.get("source_name") != source_name:
+            continue
+        out.append({
+            "type": rel.get("type", ""),
+            "target": rel.get("target_name", ""),
+            "target_label": rel.get("target_label", ""),
+        })
+    if not out:
+        return ""
+    out.sort(key=lambda e: (e["type"], e["target"]))
+    lines = [CCG_EDGES_OPEN]
+    for edge in out:
+        lines.append(f"- type: {edge['type']}")
+        lines.append(f"  target: {edge['target']}")
+        if edge["target_label"]:
+            lines.append(f"  target_label: {edge['target_label']}")
+    lines.append(CCG_EDGES_CLOSE)
+    return "\n".join(lines)
+
+
+def _description_with_edges(base: str, relationships: list[dict[str, Any]], source_name: str) -> str:
+    block = _build_ccg_edges_block(relationships, source_name)
+    return f"{base}\n\n{block}" if block else base
+
+
 # ---------------------------------------------------------------------------
 # Fixture ingestion (NAMS)
 # ---------------------------------------------------------------------------
@@ -68,52 +105,69 @@ _POLE_TYPE_HINTS = {
 
 
 async def ingest_fixtures_nams(fixture_data: dict[str, Any], domain_id: str) -> None:
-    """Best-effort B-partial port of ``data/fixtures.json`` into NAMS.
+    """Ingest ``data/fixtures.json`` into NAMS using the hybrid write shape.
 
-    Entities land with all properties markdown-serialized into the description
-    field. Relationships, preferences, and facts are unsupported by the NAMS
-    write API and logged-skipped. Documents land as ``role="document"``
-    short-term messages. Decision traces land via the reasoning REST API.
+    * Entities → ``long_term.add_entity`` with attributes serialized into
+      ``description`` and outbound relationships encoded as a fenced
+      ``ccg-edges`` YAML block (migrates to native edges when NAMS gains
+      ``add_relationship``).
+    * Documents → dual-tracked: ``add_entity(name=title, type=OBJECT)`` so
+      the document is a queryable long-term entity AND
+      ``short_term.add_message(role="document")`` so the NAMS extractor
+      sees the prose.
+    * Decision traces use the reasoning REST API.
     """
     client = get_client()
     if client is None:
         print("  [warn] NAMS client not connected. Run from inside the FastAPI lifespan or set MEMORY_API_KEY.")
         return
 
-    # 1. Entities
+    relationships = fixture_data.get("relationships", [])
     entities = fixture_data.get("entities", {})
     entity_count = 0
+    edges_encoded = 0
     for label, items in entities.items():
         pole_type = _POLE_TYPE_HINTS.get(label, "OBJECT")
         for item in items:
             name = item.get("name") or f"{label}-{entity_count}"
+            base = _serialize_entity_to_description(item, label, pole_type)
+            description = _description_with_edges(base, relationships, name)
+            if description is not base:
+                edges_encoded += 1
             try:
                 await client.long_term.add_entity(
                     name=name,
                     entity_type=pole_type,
-                    description=_serialize_entity_to_description(item, label, pole_type),
+                    description=description,
                 )
                 entity_count += 1
             except Exception as e:
                 print(f"  [warn] Entity {name}: {e}")
-    print(f"  [1/4] Ingested {entity_count} entities")
+    print(f"  [1/3] Ingested {entity_count} entities ({edges_encoded} with ccg-edges)")
 
-    # 2. Relationships (logged-skipped)
-    rel_count = len(fixture_data.get("relationships", []))
-    if rel_count:
-        print(f"  [2/4] Skipped {rel_count} relationships — not supported by NAMS write API")
-
-    # 3. Documents → short-term messages
+    # Documents → dual-tracked
     doc_session = f"docs-{domain_id}"
     doc_count = 0
     for doc in fixture_data.get("documents", []):
+        title = doc.get("title", "")
+        if not title:
+            continue
+        content = doc.get("content", "")
+        base = (
+            f"{content}\n\n_pole_type: OBJECT_"
+            if content else f"Document: {title}\n\n_pole_type: OBJECT_"
+        )
+        description = _description_with_edges(base, relationships, title)
         try:
+            await client.long_term.add_entity(
+                name=title, entity_type="OBJECT", description=description,
+            )
             await client.short_term.add_message(
                 session_id=doc_session,
                 role="document",
-                content=doc.get("content", ""),
+                content=content,
                 metadata={
-                    "title": doc.get("title", ""),
+                    "title": title,
                     "template_id": doc.get("template_id", ""),
                     "template_name": doc.get("template_name", ""),
                     "domain": domain_id,
@@ -121,8 +175,8 @@ async def ingest_fixtures_nams(fixture_data: dict[str, Any], domain_id: str) -> 
             )
             doc_count += 1
         except Exception as e:
-            print(f"  [warn] Document: {e}")
-    print(f"  [3/4] Ingested {doc_count} documents (as role=document messages)")
+            print(f"  [warn] Document {title}: {e}")
+    print(f"  [2/3] Ingested {doc_count} documents (dual-tracked: entity + message)")
 
     # 4. Decision traces via reasoning API
     trace_session = f"traces-{domain_id}"
@@ -149,12 +203,39 @@ async def ingest_fixtures_nams(fixture_data: dict[str, Any], domain_id: str) -> 
             trace_count += 1
         except Exception as e:
             print(f"  [warn] Trace: {e}")
-    print(f"  [4/4] Ingested {trace_count} decision traces")
+    print(f"  [3/3] Ingested {trace_count} decision traces")
 
 
 # ---------------------------------------------------------------------------
-# Documents — on NAMS, stored as short-term messages with role="document"
+# Documents — on NAMS, stored as long-term Document entities (queryable).
+# The same content is mirrored into short_term as role="document" messages so
+# the NAMS extractor can mine the prose, but the entity is the source of
+# truth for the document browser (matches the bolt graph shape).
 # ---------------------------------------------------------------------------
+
+
+_DOCUMENT_QUERY_HINT = "Document"
+
+
+def _document_record_from_entity(entity: Any) -> dict[str, Any] | None:
+    """Convert a long_term entity record into the doc-browser shape, or None
+    if the entity doesn't look like a Document (missing/empty description)."""
+    name = getattr(entity, "name", None) or getattr(entity, "entity_name", None)
+    if not name:
+        return None
+    description = getattr(entity, "description", "") or ""
+    # Strip the ccg-edges YAML block and the trailing _pole_type: marker
+    # before returning a clean preview.
+    content = description
+    if "```ccg-edges" in content:
+        content = content.split("```ccg-edges", 1)[0].rstrip()
+    if "_pole_type:" in content:
+        content = content.rsplit("_pole_type:", 1)[0].rstrip()
+    return {
+        "title": name,
+        "content": content,
+        "preview": content[:200],
+    }
 
 
 async def list_documents_nams(
@@ -163,34 +244,35 @@ async def list_documents_nams(
     client = get_client()
     if client is None:
         return []
-    session_id = f"docs-{settings.domain_id}"
     try:
-        conversation = await client.short_term.get_conversation(session_id=session_id)
-        messages = getattr(conversation, "messages", []) or []
+        entities = await client.long_term.search_entities(
+            query=_DOCUMENT_QUERY_HINT, limit=skip + limit + 50,
+        )
     except Exception as e:
-        logger.info("list_documents_nams: get_conversation failed: %s", e)
+        logger.info("list_documents_nams: search_entities failed: %s", e)
         return []
 
     docs: list[dict[str, Any]] = []
-    for msg in messages:
-        meta = getattr(msg, "metadata", None) or {}
-        if not isinstance(meta, dict):
-            try:
-                meta = json.loads(meta)  # type: ignore[arg-type]
-            except Exception:
-                meta = {}
-        if template_id and meta.get("template_id") != template_id:
+    for ent in entities:
+        ent_type = getattr(ent, "entity_type", None) or getattr(ent, "type", None)
+        # NAMS doesn't have a Document label; we stored docs as type=OBJECT
+        # with the doc title as the entity name. Filter by description shape
+        # — anything without prose is not a document.
+        rec = _document_record_from_entity(ent)
+        if rec is None:
             continue
-        content = getattr(msg, "content", "") or ""
-        docs.append(
-            {
-                "title": meta.get("title", "(untitled)"),
-                "template_id": meta.get("template_id", ""),
-                "template_name": meta.get("template_name", ""),
-                "preview": content[:200],
-                "mentioned_entities": [],
-            }
-        )
+        # Coarse filter: skip records that are clearly POLE+O typed people /
+        # organizations / locations / events, leaving only OBJECTs which is
+        # what documents land as.
+        if ent_type and ent_type.upper() not in {"OBJECT", "DOCUMENT"}:
+            continue
+        rec["template_id"] = ""
+        rec["template_name"] = ""
+        rec["mentioned_entities"] = []
+        if template_id and rec["template_id"] != template_id:
+            continue
+        docs.append(rec)
+
     docs.sort(key=lambda d: d.get("title", ""))
     return docs[skip : skip + limit]
 
@@ -199,31 +281,27 @@ async def get_document_nams(title: str) -> dict[str, Any] | None:
     client = get_client()
     if client is None:
         return None
-    session_id = f"docs-{settings.domain_id}"
     try:
-        conversation = await client.short_term.get_conversation(session_id=session_id)
-        messages = getattr(conversation, "messages", []) or []
+        entities = await client.long_term.search_entities(query=title, limit=20)
     except Exception:
         return None
 
-    for msg in messages:
-        meta = getattr(msg, "metadata", None) or {}
-        if not isinstance(meta, dict):
-            try:
-                meta = json.loads(meta)  # type: ignore[arg-type]
-            except Exception:
-                meta = {}
-        if meta.get("title") == title:
-            content = getattr(msg, "content", "") or ""
-            return {
-                "document": {
-                    "title": title,
-                    "content": content,
-                    "template_id": meta.get("template_id", ""),
-                    "template_name": meta.get("template_name", ""),
-                },
-                "mentioned_entities": [],
-            }
+    for ent in entities:
+        name = getattr(ent, "name", None) or getattr(ent, "entity_name", None)
+        if name != title:
+            continue
+        rec = _document_record_from_entity(ent)
+        if rec is None:
+            return None
+        return {
+            "document": {
+                "title": title,
+                "content": rec["content"],
+                "template_id": "",
+                "template_name": "",
+            },
+            "mentioned_entities": [],
+        }
     return None
 
 

--- a/src/create_context_graph/templates/backend/shared/memory_adapter.py.j2
+++ b/src/create_context_graph/templates/backend/shared/memory_adapter.py.j2
@@ -125,11 +125,15 @@ async def ingest_fixtures_nams(fixture_data: dict[str, Any], domain_id: str) -> 
     relationships = fixture_data.get("relationships", [])
     entities = fixture_data.get("entities", {})
     entity_count = 0
+    fallback_name_index = 0
     edges_encoded = 0
     for label, items in entities.items():
         pole_type = _POLE_TYPE_HINTS.get(label, "OBJECT")
         for item in items:
-            name = item.get("name") or f"{label}-{entity_count}"
+            name = item.get("name")
+            if not name:
+                name = f"{label}-{fallback_name_index}"
+                fallback_name_index += 1
             base = _serialize_entity_to_description(item, label, pole_type)
             description = _description_with_edges(base, relationships, name)
             if description is not base:

--- a/src/create_context_graph/templates/backend/shared/memory_adapter.py.j2
+++ b/src/create_context_graph/templates/backend/shared/memory_adapter.py.j2
@@ -227,8 +227,8 @@ def _document_record_from_entity(entity: Any) -> dict[str, Any] | None:
     # Strip the ccg-edges YAML block and the trailing _pole_type: marker
     # before returning a clean preview.
     content = description
-    if "```ccg-edges" in content:
-        content = content.split("```ccg-edges", 1)[0].rstrip()
+    if CCG_EDGES_OPEN in content:
+        content = content.split(CCG_EDGES_OPEN, 1)[0].rstrip()
     if "_pole_type:" in content:
         content = content.rsplit("_pole_type:", 1)[0].rstrip()
     if not content.strip():

--- a/src/create_context_graph/templates/backend/shared/routes.py.j2
+++ b/src/create_context_graph/templates/backend/shared/routes.py.j2
@@ -302,9 +302,14 @@ async def pagerank():
 
 @router.get("/documents")
 async def list_documents(template_id: str | None = None, skip: int = 0, limit: int = 50):
-    """List documents, optionally filtered by template type."""
+    """List documents; template filtering is only available on bolt."""
     _require_neo4j()
     if _is_nams():
+        if template_id:
+            raise HTTPException(
+                status_code=501,
+                detail="Document template filtering is not supported on the NAMS backend.",
+            )
         results = await list_documents_nams(template_id, skip, limit)
         return {"documents": results}
     if template_id:

--- a/src/create_context_graph/templates/base/Makefile.j2
+++ b/src/create_context_graph/templates/base/Makefile.j2
@@ -131,13 +131,20 @@ mcp-server:  ## Start MCP server for Claude Desktop
 {% endif %}
 
 {% if saas_connectors %}
-# Fetch real data from connected services into data/fixtures.json
+# Fetch from connected services and ingest into the configured memory backend
+# (NAMS or self-hosted bolt). Idempotent: each connector tracks a watermark in
+# .context-graph/watermarks.json so re-runs only fetch deltas.
 import:
 	cd backend && uv run python scripts/import_data.py
 
-# Fetch real data and ingest it into Neo4j (schema + import + seed in one step)
-import-and-seed: import
-	cd backend && uv run python scripts/generate_data.py
+# Fetch only (no ingest). Writes data/fixtures.json for inspection.
+import-dry-run:
+	cd backend && uv run python scripts/import_data.py --dry-run
+
+# Drain .context-graph/deadletter.jsonl back through the writer. Use after an
+# outage / partial-failure import to re-attempt the failed records.
+import-retry:
+	cd backend && uv run python scripts/import_data.py --retry
 {% endif %}
 
 # Test

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -805,7 +805,8 @@ class TestClaudeCodeConnectorCLI:
         assert "claude_code_base_path" in config_py
 
     def test_claude_code_import_data_dict_access(self, runner, tmp_path):
-        """Generated import_data.py should use dict access, not attribute access."""
+        """Generated import_data.py should treat connector output as a dict
+        (NormalizedData is coerced via ``_normalized_to_dict``)."""
         out = tmp_path / "cc-dict"
         result = runner.invoke(main, [
             "cc-dict",
@@ -816,8 +817,10 @@ class TestClaudeCodeConnectorCLI:
         ])
         assert result.exit_code == 0, result.output
         import_data = (out / "backend" / "scripts" / "import_data.py").read_text()
-        assert 'data["entities"]' in import_data
+        # New shape: connector return is dict-coerced then accessed via .get
+        assert 'data.get("entities"' in import_data
         assert "data.entities" not in import_data
+        assert "_normalized_to_dict" in import_data
 
     def test_claude_code_connector_entity_types(self, runner, tmp_path):
         """Generated connector should extract all entity types including Decision/Preference."""

--- a/tests/test_doc_snippets.py
+++ b/tests/test_doc_snippets.py
@@ -310,28 +310,45 @@ class TestEnvVariables:
         )
 
 
-class TestNamsRelationshipWorkaround:
-    """The bolt-first NAMS workaround must be discoverable in the docs."""
+class TestNamsRelationshipEncoding:
+    """Both the docs and the code must describe the ccg-edges encoding the
+    NAMS path uses in lieu of native relationships."""
 
-    def test_use_nams_doc_covers_relationship_seeding(self):
+    def test_use_nams_doc_covers_ccg_edges_encoding(self):
         doc = (DOCS_DIR / "how-to" / "use-nams.md").read_text()
-        # Section heading + both option labels + the agreed mitigation phrase.
+        # The encoding section heading + the literal fence marker + a
+        # readable example so users know what they're looking at.
         assert "Seeding a relationship-rich graph" in doc
-        assert "Option A" in doc and "Option B" in doc
-        # The recommended bolt-first flow should be explicit, including --demo.
+        assert "ccg-edges" in doc
+        # The self-hosted escape hatch must still be discoverable for users
+        # who need native edges today.
         assert "--self-hosted" in doc
         assert "--demo" in doc
-        # And the doc should call out the upstream tracking marker so the two
-        # references stay in sync when the API lands.
-        assert "TODO(nams-relationships)" in doc
 
-    def test_ingest_py_has_tracked_todo_marker(self):
+    def test_ingest_py_uses_ccg_edges_marker(self):
         ingest = (
             Path(__file__).resolve().parent.parent
             / "src"
             / "create_context_graph"
             / "ingest.py"
         ).read_text()
-        # The marker is the contract the docs reference — it tells future
-        # contributors where to plug in MemoryClient.add_relationship.
-        assert "TODO(nams-relationships)" in ingest
+        # The marker is the single seam future contributors swap when NAMS
+        # ships add_relationship; the contract test pins both consumers
+        # to its output.
+        assert "ccg-edges" in ingest
+        assert "_build_ccg_edges_block" in ingest
+
+    def test_scaffold_template_uses_ccg_edges_marker(self):
+        template = (
+            Path(__file__).resolve().parent.parent
+            / "src"
+            / "create_context_graph"
+            / "templates"
+            / "backend"
+            / "connectors"
+            / "import_data.py.j2"
+        ).read_text()
+        # The scaffolded path must use the same encoding so generated apps
+        # produce graph-identical output to the CLI ingest.
+        assert "ccg-edges" in template
+        assert "_build_ccg_edges_block" in template

--- a/tests/test_ingest_nams.py
+++ b/tests/test_ingest_nams.py
@@ -358,6 +358,31 @@ class TestIngestDataDispatch:
         # SHOULD have hit graph.execute_write (schema + rels + docs + traces)
         assert bolt_client.graph.execute_write.await_count > 0
 
+    def test_legacy_bolt_signature_still_dispatches(
+        self, tmp_path, healthcare_ontology, monkeypatch
+    ):
+        fixture = _make_fixture_file(tmp_path)
+        import create_context_graph.ingest as ingest_module
+
+        memory_client_ingest = AsyncMock()
+        monkeypatch.setattr(ingest_module, "_ingest_with_memory_client", memory_client_ingest)
+        monkeypatch.setitem(sys.modules, "neo4j_agent_memory", ModuleType("neo4j_agent_memory"))
+
+        ingest_data(
+            fixture,
+            healthcare_ontology,
+            "neo4j://legacy-host:7687",
+            "legacy-user",
+            "legacy-pass",
+        )
+
+        assert memory_client_ingest.await_count == 1
+        assert memory_client_ingest.await_args.args[2:] == (
+            "neo4j://legacy-host:7687",
+            "legacy-user",
+            "legacy-pass",
+        )
+
 
 # ---------------------------------------------------------------------------
 # reset_memory_store dispatch

--- a/tests/test_ingest_nams.py
+++ b/tests/test_ingest_nams.py
@@ -26,6 +26,7 @@ import pytest
 from create_context_graph.config import ProjectConfig
 from create_context_graph.ingest import (
     _get_pole_type,
+    _require_safe_cypher_identifier,
     _serialize_entity_to_description,
     ingest_data,
     reset_memory_store,
@@ -184,6 +185,15 @@ class TestSerializeEntityToDescription:
         assert "**Zero**" in desc
         assert "**Empty str**" not in desc
         assert "**None value**" not in desc
+
+
+class TestSafeCypherIdentifier:
+    def test_accepts_simple_identifier(self):
+        assert _require_safe_cypher_identifier("Patient_Record", "label") == "Patient_Record"
+
+    def test_rejects_punctuation(self):
+        with pytest.raises(ValueError, match="Unsafe Cypher label"):
+            _require_safe_cypher_identifier("Bad Label", "label")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingest_nams.py
+++ b/tests/test_ingest_nams.py
@@ -204,14 +204,15 @@ class TestIngestDataDispatch:
         )
         ingest_data(fixture, healthcare_ontology, cfg)
 
-        # 3 entities total in the fixture (2 patients + 1 hospital)
-        assert fake_client.long_term.add_entity.await_count == 3
+        # 3 typed entities (2 patients + 1 hospital) + 1 dual-tracked
+        # Document entity = 4 add_entity calls total.
+        assert fake_client.long_term.add_entity.await_count == 4
         first_kwargs = fake_client.long_term.add_entity.await_args_list[0].kwargs
         assert first_kwargs["name"] == "Alice Park"
         assert first_kwargs["entity_type"] in {"PERSON", "ORGANIZATION", "LOCATION", "EVENT", "OBJECT"}
         assert "_pole_type:" in first_kwargs["description"]
 
-    def test_nams_path_skips_relationships(
+    def test_nams_path_encodes_relationships_as_ccg_edges(
         self, tmp_path, healthcare_ontology, fake_client, fake_nams_module, capsys
     ):
         fixture = _make_fixture_file(tmp_path)
@@ -222,12 +223,27 @@ class TestIngestDataDispatch:
             nams_api_key="sk-test",
         )
         ingest_data(fixture, healthcare_ontology, cfg)
-        captured = capsys.readouterr()
-        assert "relationships not persisted" in captured.out
 
-    def test_nams_path_stores_documents_as_messages(
+        # Alice has an outbound TREATED_AT edge in the fixture — her
+        # description must carry the encoded ccg-edges block.
+        alice_call = next(
+            c for c in fake_client.long_term.add_entity.await_args_list
+            if c.kwargs.get("name") == "Alice Park"
+        )
+        description = alice_call.kwargs["description"]
+        assert "```ccg-edges" in description
+        assert "type: TREATED_AT" in description
+        assert "target: Mercy General" in description
+
+        # The user-facing summary should report the encoding, not a skip.
+        captured = capsys.readouterr()
+        assert "ccg-edges" in captured.out
+
+    def test_nams_path_dual_tracks_documents(
         self, tmp_path, healthcare_ontology, fake_client, fake_nams_module
     ):
+        """Documents become BOTH a long_term entity (queryable) AND a
+        short_term message (extraction fuel for NAMS)."""
         fixture = _make_fixture_file(tmp_path)
         cfg = ProjectConfig(
             project_name="x",
@@ -237,11 +253,23 @@ class TestIngestDataDispatch:
         )
         ingest_data(fixture, healthcare_ontology, cfg)
 
+        # Document message side.
         assert fake_client.short_term.add_message.await_count == 1
-        kwargs = fake_client.short_term.add_message.await_args.kwargs
-        assert kwargs["role"] == "document"
-        assert kwargs["session_id"].startswith("docs-")
-        assert kwargs["metadata"]["title"] == "Discharge Note — Bob Singh"
+        msg_kwargs = fake_client.short_term.add_message.await_args.kwargs
+        assert msg_kwargs["role"] == "document"
+        assert msg_kwargs["session_id"].startswith("docs-")
+        assert msg_kwargs["metadata"]["title"] == "Discharge Note — Bob Singh"
+
+        # Document entity side.
+        doc_entity_call = next(
+            (c for c in fake_client.long_term.add_entity.await_args_list
+             if c.kwargs.get("name") == "Discharge Note — Bob Singh"),
+            None,
+        )
+        assert doc_entity_call is not None, (
+            "Document was not also written as a long_term entity — dual-tracking broken"
+        )
+        assert doc_entity_call.kwargs["entity_type"] == "OBJECT"
 
     def test_nams_path_creates_traces_via_reasoning_api(
         self, tmp_path, healthcare_ontology, fake_client, fake_nams_module

--- a/tests/test_memory_adapter.py
+++ b/tests/test_memory_adapter.py
@@ -195,6 +195,19 @@ class TestListDocuments:
         assert "_pole_type" not in result[0]["preview"]
         assert "chest pain" in result[0]["preview"]
 
+    def test_skips_blank_description_after_stripping_metadata(self, nams_adapter):
+        adapter, memory_mod = nams_adapter
+        entity = SimpleNamespace(
+            name="EmptyDoc",
+            entity_type="OBJECT",
+            description="```ccg-edges\n- type: MENTIONS\n  target: Alice\n```\n\n_pole_type: OBJECT_",
+        )
+        client = MagicMock()
+        client.long_term.search_entities = AsyncMock(return_value=[entity])
+        memory_mod._client = client
+
+        assert _run(adapter.list_documents_nams(None, 0, 50)) == []
+
 
 # ---------------------------------------------------------------------------
 # get_document_nams
@@ -223,6 +236,15 @@ class TestGetDocument:
         client.long_term.search_entities = AsyncMock(return_value=[])
         memory_mod._client = client
         assert _run(adapter.get_document_nams("missing")) is None
+
+    def test_returns_none_when_content_is_blank_after_stripping_metadata(self, nams_adapter):
+        adapter, memory_mod = nams_adapter
+        entity = _make_doc_entity("DocB", content="")
+        client = MagicMock()
+        client.long_term.search_entities = AsyncMock(return_value=[entity])
+        memory_mod._client = client
+
+        assert _run(adapter.get_document_nams("DocB")) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_adapter.py
+++ b/tests/test_memory_adapter.py
@@ -104,51 +104,49 @@ def _run(coro):
 # ---------------------------------------------------------------------------
 
 
+def _make_doc_entity(title: str, content: str = "doc body", entity_type: str = "OBJECT"):
+    """Synthesize what NAMS long_term.search_entities returns for a Document.
+
+    The new adapter looks at ``entity_type`` (filters to OBJECT/DOCUMENT) and
+    ``description`` (parses out the ccg-edges block + _pole_type marker).
+    """
+    description = f"{content}\n\n_pole_type: {entity_type}_"
+    return SimpleNamespace(name=title, entity_type=entity_type, description=description)
+
+
 class TestListDocuments:
-    def test_returns_documents_from_messages(self, nams_adapter):
+    def test_returns_documents_from_long_term_entities(self, nams_adapter):
         adapter, memory_mod = nams_adapter
-        messages = [
-            SimpleNamespace(
-                content="Discharge note content...",
-                metadata={"title": "Discharge — Alice", "template_id": "discharge",
-                          "template_name": "Discharge Note"},
-            ),
-            SimpleNamespace(
-                content="Lab results page 1...",
-                metadata={"title": "Labs — Bob", "template_id": "labs",
-                          "template_name": "Lab Report"},
-            ),
+        entities = [
+            _make_doc_entity("Discharge — Alice", "Discharge note content..."),
+            _make_doc_entity("Labs — Bob", "Lab results page 1..."),
         ]
         client = MagicMock()
-        client.short_term.get_conversation = AsyncMock(
-            return_value=SimpleNamespace(messages=messages)
-        )
+        client.long_term.search_entities = AsyncMock(return_value=entities)
         memory_mod._client = client
 
         result = _run(adapter.list_documents_nams(None, 0, 50))
         assert len(result) == 2
         titles = {d["title"] for d in result}
         assert titles == {"Discharge — Alice", "Labs — Bob"}
-        # preview truncated to 200 chars
         for d in result:
             assert len(d["preview"]) <= 200
 
-    def test_filters_by_template_id(self, nams_adapter):
+    def test_skips_typed_non_document_entities(self, nams_adapter):
+        """Person/Organization/etc. entities returned by the search should be
+        filtered out — only OBJECT-typed records are treated as documents."""
         adapter, memory_mod = nams_adapter
-        messages = [
-            SimpleNamespace(content="...", metadata={"title": "A", "template_id": "discharge"}),
-            SimpleNamespace(content="...", metadata={"title": "B", "template_id": "labs"}),
-            SimpleNamespace(content="...", metadata={"title": "C", "template_id": "discharge"}),
+        entities = [
+            _make_doc_entity("DocA", entity_type="OBJECT"),
+            _make_doc_entity("Dr. Smith", entity_type="PERSON"),
+            _make_doc_entity("Mercy General", entity_type="ORGANIZATION"),
         ]
         client = MagicMock()
-        client.short_term.get_conversation = AsyncMock(
-            return_value=SimpleNamespace(messages=messages)
-        )
+        client.long_term.search_entities = AsyncMock(return_value=entities)
         memory_mod._client = client
 
-        result = _run(adapter.list_documents_nams("discharge", 0, 50))
-        assert len(result) == 2
-        assert {d["title"] for d in result} == {"A", "C"}
+        result = _run(adapter.list_documents_nams(None, 0, 50))
+        assert {d["title"] for d in result} == {"DocA"}
 
     def test_returns_empty_when_client_is_none(self, nams_adapter):
         adapter, memory_mod = nams_adapter
@@ -159,26 +157,43 @@ class TestListDocuments:
     def test_returns_empty_when_client_errors(self, nams_adapter):
         adapter, memory_mod = nams_adapter
         client = MagicMock()
-        client.short_term.get_conversation = AsyncMock(side_effect=RuntimeError("oops"))
+        client.long_term.search_entities = AsyncMock(side_effect=RuntimeError("oops"))
         memory_mod._client = client
         result = _run(adapter.list_documents_nams(None, 0, 50))
         assert result == []
 
     def test_pagination_skip_and_limit(self, nams_adapter):
         adapter, memory_mod = nams_adapter
-        messages = [
-            SimpleNamespace(content=str(i), metadata={"title": f"Doc-{i:02d}"})
-            for i in range(10)
-        ]
+        entities = [_make_doc_entity(f"Doc-{i:02d}", content=str(i)) for i in range(10)]
         client = MagicMock()
-        client.short_term.get_conversation = AsyncMock(
-            return_value=SimpleNamespace(messages=messages)
-        )
+        client.long_term.search_entities = AsyncMock(return_value=entities)
         memory_mod._client = client
 
         page = _run(adapter.list_documents_nams(None, skip=3, limit=4))
         assert len(page) == 4
         assert [d["title"] for d in page] == ["Doc-03", "Doc-04", "Doc-05", "Doc-06"]
+
+    def test_strips_ccg_edges_block_from_preview(self, nams_adapter):
+        """The ccg-edges YAML block is an implementation detail; previews
+        shown in the document browser must not include it."""
+        adapter, memory_mod = nams_adapter
+        description = (
+            "Real document body about chest pain workup.\n\n"
+            "```ccg-edges\n- type: MENTIONS\n  target: Alice Park\n```\n\n"
+            "_pole_type: OBJECT_"
+        )
+        entity = SimpleNamespace(
+            name="ClinicalNote-1", entity_type="OBJECT", description=description,
+        )
+        client = MagicMock()
+        client.long_term.search_entities = AsyncMock(return_value=[entity])
+        memory_mod._client = client
+
+        result = _run(adapter.list_documents_nams(None, 0, 50))
+        assert len(result) == 1
+        assert "ccg-edges" not in result[0]["preview"]
+        assert "_pole_type" not in result[0]["preview"]
+        assert "chest pain" in result[0]["preview"]
 
 
 # ---------------------------------------------------------------------------
@@ -189,14 +204,12 @@ class TestListDocuments:
 class TestGetDocument:
     def test_returns_full_content_by_title(self, nams_adapter):
         adapter, memory_mod = nams_adapter
-        messages = [
-            SimpleNamespace(content="content-A", metadata={"title": "DocA"}),
-            SimpleNamespace(content="content-B", metadata={"title": "DocB"}),
+        entities = [
+            _make_doc_entity("DocA", content="content-A"),
+            _make_doc_entity("DocB", content="content-B"),
         ]
         client = MagicMock()
-        client.short_term.get_conversation = AsyncMock(
-            return_value=SimpleNamespace(messages=messages)
-        )
+        client.long_term.search_entities = AsyncMock(return_value=entities)
         memory_mod._client = client
 
         result = _run(adapter.get_document_nams("DocB"))
@@ -207,9 +220,7 @@ class TestGetDocument:
     def test_returns_none_when_not_found(self, nams_adapter):
         adapter, memory_mod = nams_adapter
         client = MagicMock()
-        client.short_term.get_conversation = AsyncMock(
-            return_value=SimpleNamespace(messages=[])
-        )
+        client.long_term.search_entities = AsyncMock(return_value=[])
         memory_mod._client = client
         assert _run(adapter.get_document_nams("missing")) is None
 
@@ -430,18 +441,23 @@ class TestIngestFixturesNams:
         }
         _run(adapter.ingest_fixtures_nams(fixture, "healthcare"))
 
-        # 2 entities created (1 patient + 1 hospital)
-        assert client.long_term.add_entity.await_count == 2
-        # 1 document → 1 short-term message
+        # 2 typed entities + 1 dual-tracked Document entity = 3 add_entity calls
+        assert client.long_term.add_entity.await_count == 3
+        # 1 document → 1 short-term message (no body fields in this fixture)
         assert client.short_term.add_message.await_count == 1
         # 1 trace with 1 step
         assert client.reasoning.start_trace.await_count == 1
         assert client.reasoning.add_step.await_count == 1
         assert client.reasoning.complete_trace.await_count == 1
 
-        # Relationship skip is logged to stdout (not an exception)
-        captured = capsys.readouterr()
-        assert "Skipped 1 relationships" in captured.out
+        # Alice's outbound TREATED_AT edge must be encoded into her description
+        # as a ccg-edges block (NAMS REST has no add_relationship yet).
+        alice_call = next(
+            c for c in client.long_term.add_entity.await_args_list
+            if c.kwargs.get("name") == "Alice"
+        )
+        assert "```ccg-edges" in alice_call.kwargs["description"]
+        assert "TREATED_AT" in alice_call.kwargs["description"]
 
     def test_handles_missing_client_gracefully(self, nams_adapter, capsys):
         adapter, memory_mod = nams_adapter

--- a/tests/test_nams_adapter.py
+++ b/tests/test_nams_adapter.py
@@ -74,7 +74,9 @@ class TestProjectConfigNamsDefaults:
 
 
 class TestEntitySerializer:
-    """The B-partial port packs entity attributes into the description field."""
+    """Entity attributes are markdown-serialized into the description field
+    (NAMS REST only accepts {name, type, description}); relationships are
+    appended as a separate ccg-edges block by callers."""
 
     def test_basic_fields_render(self):
         out = _serialize_entity_to_description(

--- a/tests/test_nams_ingest_parity.py
+++ b/tests/test_nams_ingest_parity.py
@@ -469,3 +469,58 @@ def test_bolt_ingest_rejects_unsafe_cypher_identifiers():
 
     assert counts["failures"] == 2
     session.run.assert_not_called()
+
+
+def test_bolt_ingest_uses_relationship_labels_when_present():
+    ns = _exec_scaffold_template(_RecordingClient())
+
+    class _Session:
+        def __init__(self):
+            self.run = MagicMock()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return None
+
+    session = _Session()
+    driver = MagicMock()
+    driver.session.return_value = session
+    prior = sys.modules.get("app.context_graph_client")
+    try:
+        cgc_mod = ModuleType("app.context_graph_client")
+        cgc_mod.get_driver = MagicMock(return_value=driver)
+        sys.modules["app.context_graph_client"] = cgc_mod
+
+        counts = ns["_ingest_via_bolt"](
+            {
+                "entities": {},
+                "relationships": [
+                    {
+                        "type": "TREATS",
+                        "source_name": "Mercy General",
+                        "source_label": "Hospital",
+                        "target_name": "Mercy General",
+                        "target_label": "Provider",
+                    }
+                ],
+                "documents": [],
+                "traces": [],
+            },
+            {},
+        )
+    finally:
+        if prior is None:
+            sys.modules.pop("app.context_graph_client", None)
+        else:
+            sys.modules["app.context_graph_client"] = prior
+
+    assert counts["relationships"] == 1
+    assert counts["failures"] == 0
+    session.run.assert_called_once()
+    cypher, params = session.run.call_args.args
+    assert "MATCH (a:Hospital {name: $source_name})" in cypher
+    assert "MATCH (b:Provider {name: $target_name})" in cypher
+    assert "MERGE (a)-[r:TREATS]->(b)" in cypher
+    assert params == {"source_name": "Mercy General", "target_name": "Mercy General"}

--- a/tests/test_nams_ingest_parity.py
+++ b/tests/test_nams_ingest_parity.py
@@ -24,6 +24,7 @@ in the other.
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -157,7 +158,7 @@ def _clean(kw: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _exec_scaffold_template(client: _RecordingClient) -> Any:
+def _exec_scaffold_template(client: _RecordingClient) -> dict[str, Any]:
     """Render import_data.py.j2 enough to extract its ``_ingest_via_nams``
     function, then return a bound callable that uses ``client``."""
     template_path = (
@@ -209,7 +210,7 @@ def _exec_scaffold_template(client: _RecordingClient) -> Any:
         "__file__": str(synthetic_root / "backend" / "scripts" / "import_data.py"),
     }
     exec(compile(rendered, str(template_path), "exec"), ns)
-    return ns["_ingest_via_nams"]
+    return ns
 
 
 def _run_cli_path(client: _RecordingClient) -> list[tuple[str, dict[str, Any]]]:
@@ -226,21 +227,31 @@ def _run_cli_path(client: _RecordingClient) -> list[tuple[str, dict[str, Any]]]:
 
 
 def _run_scaffold_path(client: _RecordingClient) -> list[tuple[str, dict[str, Any]]]:
-    ingest_via_nams = _exec_scaffold_template(client)
+    prior_modules = {
+        name: sys.modules.get(name)
+        for name in ("app", "app.config", "app.connectors", "neo4j_agent_memory")
+    }
+    try:
+        ns = _exec_scaffold_template(client)
+        ingest_via_nams = ns["_ingest_via_nams"]
 
-    # The scaffolded path also writes failures to a deadletter file; point it
-    # at a temp dir so we don't pollute the repo.
-    import tempfile
+        # The scaffolded path also writes failures to a deadletter file; point it
+        # at a temp dir so we don't pollute the repo.
+        import tempfile
 
-    with tempfile.TemporaryDirectory() as tmp:
-        # The template hard-codes PROJECT_ROOT relative to the script file;
-        # we monkeypatch SIDECAR_DIR in the exec'd namespace.
-        ns = ingest_via_nams.__globals__
-        ns["SIDECAR_DIR"] = Path(tmp)
-        ns["DEADLETTER_FILE"] = Path(tmp) / "deadletter.jsonl"
-
-        asyncio.run(ingest_via_nams(CANONICAL_FIXTURE, BODY_FIELDS))
-    return list(client.calls)
+        with tempfile.TemporaryDirectory() as tmp:
+            # The template hard-codes PROJECT_ROOT relative to the script file;
+            # we monkeypatch SIDECAR_DIR in the exec'd namespace.
+            ns["SIDECAR_DIR"] = Path(tmp)
+            ns["DEADLETTER_FILE"] = Path(tmp) / "deadletter.jsonl"
+            asyncio.run(ingest_via_nams(CANONICAL_FIXTURE, BODY_FIELDS))
+        return list(client.calls)
+    finally:
+        for name, module in prior_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
 
 
 # ---------------------------------------------------------------------------
@@ -369,3 +380,92 @@ def test_no_relationship_writes_on_nams():
     scaffold_calls = _run_scaffold_path(_RecordingClient())
     assert all(n != "long_term.add_relationship" for n, _ in cli_calls)
     assert all(n != "long_term.add_relationship" for n, _ in scaffold_calls)
+
+
+def test_retry_deadletter_rebuilds_retryable_payloads():
+    ns = _exec_scaffold_template(_RecordingClient())
+    captured: dict[str, Any] = {}
+
+    async def _fake_ingest(payload, body_fields):
+        captured["payload"] = payload
+        captured["body_fields"] = body_fields
+        return {"failures": 0}
+
+    ns["_ingest_via_nams"] = _fake_ingest
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        deadletter = Path(tmp) / "deadletter.jsonl"
+        ns["DEADLETTER_FILE"] = deadletter
+        deadletter.write_text(
+            "\n".join(
+                json.dumps(record)
+                for record in [
+                    {"kind": "entity", "label": "Patient", "item": {"name": "Alice"}},
+                    {"kind": "entity-batch", "label": "Hospital", "items": [{"name": "Mercy"}]},
+                    {
+                        "kind": "body",
+                        "label": "Note",
+                        "item": {"name": "Note-1", "body": "hello"},
+                        "body_field": "body",
+                    },
+                    {"kind": "relationship", "rel": {"type": "ABOUT", "source_name": "Note-1", "target_name": "Alice"}},
+                    {"kind": "document", "doc": {"title": "Doc", "content": "body"}},
+                    {"kind": "trace", "trace": {"id": "t1", "task": "task", "steps": []}},
+                ]
+            ) + "\n"
+        )
+
+        assert ns["_retry_deadletter"]() == 0
+
+    assert captured["payload"]["entities"]["Patient"] == [{"name": "Alice"}]
+    assert captured["payload"]["entities"]["Hospital"] == [{"name": "Mercy"}]
+    assert captured["payload"]["entities"]["Note"] == [{"name": "Note-1", "body": "hello"}]
+    assert captured["payload"]["relationships"] == [
+        {"type": "ABOUT", "source_name": "Note-1", "target_name": "Alice"},
+    ]
+    assert captured["payload"]["documents"] == [{"title": "Doc", "content": "body"}]
+    assert captured["payload"]["traces"] == [{"id": "t1", "task": "task", "steps": []}]
+    assert captured["body_fields"] == {"Note": "body"}
+
+
+def test_bolt_ingest_rejects_unsafe_cypher_identifiers():
+    ns = _exec_scaffold_template(_RecordingClient())
+
+    class _Session:
+        def __init__(self):
+            self.run = MagicMock()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return None
+
+    session = _Session()
+    driver = MagicMock()
+    driver.session.return_value = session
+    prior = sys.modules.get("app.context_graph_client")
+    try:
+        cgc_mod = ModuleType("app.context_graph_client")
+        cgc_mod.get_driver = MagicMock(return_value=driver)
+        sys.modules["app.context_graph_client"] = cgc_mod
+
+        counts = ns["_ingest_via_bolt"](
+            {
+                "entities": {"Bad Label": [{"name": "Alice"}]},
+                "relationships": [{"type": "BAD-TYPE", "source_name": "Alice", "target_name": "Bob"}],
+                "documents": [],
+                "traces": [],
+            },
+            {},
+        )
+    finally:
+        if prior is None:
+            sys.modules.pop("app.context_graph_client", None)
+        else:
+            sys.modules["app.context_graph_client"] = prior
+
+    assert counts["failures"] == 2
+    session.run.assert_not_called()

--- a/tests/test_nams_ingest_parity.py
+++ b/tests/test_nams_ingest_parity.py
@@ -1,0 +1,371 @@
+# Copyright 2026 Neo4j Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Contract test: the CLI's NAMS ingest path and the scaffolded
+``import_data.py`` must emit identical NAMS write sequences.
+
+The two paths live in different files (``src/.../ingest.py`` and the rendered
+``templates/.../import_data.py.j2``) on purpose — see the design discussion in
+CLAUDE.md / the grill-me transcript for why duplication beats a shared upstream
+helper here. The risk that comes with duplication is drift: behavior diverges
+in one file but not the other, and we don't notice until a user does.
+
+This test pins both paths to a shared NormalizedData fixture, captures every
+NAMS client method call from each, and asserts the sequences match. If you
+change one path's behavior, this test breaks and you must mirror the change
+in the other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from create_context_graph.ingest import run_nams_ingest
+from create_context_graph.ontology import load_domain
+
+
+# ---------------------------------------------------------------------------
+# Shared canonical fixture — exercises every load-bearing branch:
+#   - entity with no body (Patient)
+#   - entity with a body field (Note.body) — must trigger add_message
+#   - entity with outbound relationships — must trigger ccg-edges encoding
+#   - document — must trigger BOTH add_entity AND add_message
+#   - decision trace — must trigger reasoning.start_trace + add_step + complete
+# ---------------------------------------------------------------------------
+
+
+CANONICAL_FIXTURE: dict[str, Any] = {
+    "entities": {
+        "Patient": [
+            {"name": "Alice Park", "age": 67, "status": "active"},
+            {"name": "Bob Singh", "age": 42, "status": "discharged"},
+        ],
+        "Note": [
+            {
+                "name": "Note-001",
+                "body": "Patient reports intermittent chest pain over 3 days.",
+                "author": "Dr. Lee",
+            },
+        ],
+        "Hospital": [
+            {"name": "Mercy General", "city": "Portland"},
+        ],
+    },
+    "relationships": [
+        # Alice → Mercy: typed source entity has an outbound edge → ccg-edges
+        {
+            "source_name": "Alice Park", "source_label": "Patient",
+            "target_name": "Mercy General", "target_label": "Hospital",
+            "type": "TREATED_AT",
+        },
+        # Note → Alice: another edge to encode
+        {
+            "source_name": "Note-001", "source_label": "Note",
+            "target_name": "Alice Park", "target_label": "Patient",
+            "type": "ABOUT",
+        },
+    ],
+    "documents": [
+        {
+            "title": "Discharge Note — Bob",
+            "content": "Patient discharged today, vitals normal.",
+            "template_id": "discharge",
+            "template_name": "Discharge Note",
+        },
+    ],
+    "traces": [
+        {
+            "id": "trace-alpha",
+            "task": "Diagnose chest pain",
+            "outcome": "Cardiology referral",
+            "steps": [
+                {"thought": "Rule out MI", "action": "Order ECG", "observation": "Normal sinus"},
+            ],
+        },
+    ],
+}
+
+BODY_FIELDS = {"Note": "body"}
+
+
+# ---------------------------------------------------------------------------
+# Recording NAMS client double
+# ---------------------------------------------------------------------------
+
+
+class _RecordingClient:
+    """Async-context-manager double that records every long_term /
+    short_term / reasoning call as a (method, kwargs) tuple."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.long_term = SimpleNamespace(
+            add_entity=AsyncMock(side_effect=self._record("long_term.add_entity")),
+        )
+        self.short_term = SimpleNamespace(
+            add_message=AsyncMock(side_effect=self._record("short_term.add_message")),
+        )
+
+        async def _start_trace(**kw):
+            self.calls.append(("reasoning.start_trace", _clean(kw)))
+            return SimpleNamespace(id=f"trace-{len(self.calls)}")
+
+        self.reasoning = SimpleNamespace(
+            start_trace=AsyncMock(side_effect=_start_trace),
+            add_step=AsyncMock(side_effect=self._record("reasoning.add_step")),
+            complete_trace=AsyncMock(side_effect=self._record("reasoning.complete_trace")),
+        )
+
+    def _record(self, name: str):
+        async def _inner(**kw):
+            self.calls.append((name, _clean(kw)))
+            return SimpleNamespace(id=f"id-{len(self.calls)}")
+        return _inner
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return None
+
+
+def _clean(kw: dict[str, Any]) -> dict[str, Any]:
+    """Normalize kwargs so dict comparison is stable across paths.
+
+    The two ingestors use slightly different session_id conventions (the CLI
+    keys docs by domain id ``docs-{domain}``; the scaffolded importer uses
+    a fixed ``docs-import`` because the running app already knows its
+    domain context). We strip session_id from the comparison — it's
+    addressing metadata, not semantic graph content.
+    """
+    return {k: v for k, v in kw.items() if k != "session_id"}
+
+
+# ---------------------------------------------------------------------------
+# Driver — render the scaffolded template, exec it in a sandbox, invoke its
+# _ingest_via_nams against the same recording client.
+# ---------------------------------------------------------------------------
+
+
+def _exec_scaffold_template(client: _RecordingClient) -> Any:
+    """Render import_data.py.j2 enough to extract its ``_ingest_via_nams``
+    function, then return a bound callable that uses ``client``."""
+    template_path = (
+        Path(__file__).parent.parent
+        / "src" / "create_context_graph" / "templates"
+        / "backend" / "connectors" / "import_data.py.j2"
+    )
+    # Strip Jinja blocks — we render with empty connectors so the only thing
+    # left is plain Python.
+    from jinja2 import Environment, FileSystemLoader
+
+    env = Environment(
+        loader=FileSystemLoader(str(template_path.parent)),
+        keep_trailing_newline=True,
+    )
+    rendered = env.get_template("import_data.py.j2").render(saas_connectors=[])
+
+    # Inject stand-ins for the modules the template imports.
+    fake_settings = SimpleNamespace(
+        memory_api_key="sk-test",
+        memory_nams_endpoint="https://test.example/v1",
+        memory_backend="nams",
+    )
+    fake_config_mod = ModuleType("app.config")
+    fake_config_mod.settings = fake_settings
+    fake_app_mod = ModuleType("app")
+    fake_connectors_mod = ModuleType("app.connectors")
+    sys.modules["app"] = fake_app_mod
+    sys.modules["app.config"] = fake_config_mod
+    sys.modules["app.connectors"] = fake_connectors_mod
+
+    # Stub neo4j_agent_memory so the dynamic import inside _ingest_via_nams
+    # returns our recording client.
+    fake_nam = ModuleType("neo4j_agent_memory")
+    fake_nam.MemoryClient = MagicMock(return_value=client)
+    fake_nam.MemorySettings = MagicMock()
+    fake_nam.NamsConfig = MagicMock()
+    sys.modules["neo4j_agent_memory"] = fake_nam
+
+    # Exec the rendered module body in a fresh namespace. The template
+    # computes PROJECT_ROOT from __file__, so we set one inside a synthetic
+    # tmp directory — the exact value doesn't matter because the test
+    # overrides SIDECAR_DIR after exec.
+    import tempfile
+    synthetic_root = Path(tempfile.gettempdir()) / "ccg_parity_test"
+    (synthetic_root / "backend" / "scripts").mkdir(parents=True, exist_ok=True)
+    ns: dict[str, Any] = {
+        "__name__": "scaffolded_import_data",
+        "__file__": str(synthetic_root / "backend" / "scripts" / "import_data.py"),
+    }
+    exec(compile(rendered, str(template_path), "exec"), ns)
+    return ns["_ingest_via_nams"]
+
+
+def _run_cli_path(client: _RecordingClient) -> list[tuple[str, dict[str, Any]]]:
+    ontology = load_domain("healthcare")
+    asyncio.run(
+        run_nams_ingest(
+            client=client,
+            fixture_data=CANONICAL_FIXTURE,
+            ontology=ontology,
+            body_fields=BODY_FIELDS,
+        )
+    )
+    return list(client.calls)
+
+
+def _run_scaffold_path(client: _RecordingClient) -> list[tuple[str, dict[str, Any]]]:
+    ingest_via_nams = _exec_scaffold_template(client)
+
+    # The scaffolded path also writes failures to a deadletter file; point it
+    # at a temp dir so we don't pollute the repo.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # The template hard-codes PROJECT_ROOT relative to the script file;
+        # we monkeypatch SIDECAR_DIR in the exec'd namespace.
+        ns = ingest_via_nams.__globals__
+        ns["SIDECAR_DIR"] = Path(tmp)
+        ns["DEADLETTER_FILE"] = Path(tmp) / "deadletter.jsonl"
+
+        asyncio.run(ingest_via_nams(CANONICAL_FIXTURE, BODY_FIELDS))
+    return list(client.calls)
+
+
+# ---------------------------------------------------------------------------
+# The actual contract assertion
+# ---------------------------------------------------------------------------
+
+
+def _strip_pole_type(seq: list[tuple[str, dict[str, Any]]]) -> list[tuple[str, dict[str, Any]]]:
+    """The CLI path uses the ontology's POLE+O mapping; the scaffolded path
+    uses a label-name heuristic. They agree on common labels (Person, etc.)
+    but Patient → PERSON on the CLI side and Patient → OBJECT on the
+    scaffolded side, because the scaffolded code doesn't know about
+    domain ontologies. We compare everything except entity_type so the rest
+    of the call sequence parity is enforced.
+
+    This is the deliberate seam between the two paths: CLI knows the domain
+    schema; the scaffolded app handles arbitrary connector-emitted labels.
+    """
+    out: list[tuple[str, dict[str, Any]]] = []
+    for name, kw in seq:
+        cleaned = {k: v for k, v in kw.items() if k != "entity_type"}
+        out.append((name, cleaned))
+    return out
+
+
+def test_cli_and_scaffold_emit_same_nams_call_sequence():
+    cli_calls = _strip_pole_type(_run_cli_path(_RecordingClient()))
+    scaffold_calls = _strip_pole_type(_run_scaffold_path(_RecordingClient()))
+
+    # Same number of writes per kind.
+    def _counts(seq):
+        out: dict[str, int] = {}
+        for name, _ in seq:
+            out[name] = out.get(name, 0) + 1
+        return out
+
+    assert _counts(cli_calls) == _counts(scaffold_calls), (
+        f"Call counts diverge:\n  CLI:      {_counts(cli_calls)}\n"
+        f"  Scaffold: {_counts(scaffold_calls)}"
+    )
+
+    # Same set of entity names written in the same order.
+    cli_entity_names = [kw.get("name") for n, kw in cli_calls if n == "long_term.add_entity"]
+    sc_entity_names = [kw.get("name") for n, kw in scaffold_calls if n == "long_term.add_entity"]
+    assert cli_entity_names == sc_entity_names, (
+        f"Entity write order diverges:\n  CLI:      {cli_entity_names}\n"
+        f"  Scaffold: {sc_entity_names}"
+    )
+
+    # The ccg-edges block must be present and identical for the entities
+    # that have outbound relationships in the canonical fixture.
+    cli_descriptions = {
+        kw.get("name"): kw.get("description", "")
+        for n, kw in cli_calls if n == "long_term.add_entity"
+    }
+    sc_descriptions = {
+        kw.get("name"): kw.get("description", "")
+        for n, kw in scaffold_calls if n == "long_term.add_entity"
+    }
+    for name in ("Alice Park", "Note-001"):
+        assert "```ccg-edges" in cli_descriptions[name], (
+            f"CLI: expected ccg-edges block for {name}, got: {cli_descriptions[name]!r}"
+        )
+        assert "```ccg-edges" in sc_descriptions[name], (
+            f"Scaffold: expected ccg-edges block for {name}, got: {sc_descriptions[name]!r}"
+        )
+        # The block content itself must be identical between the two paths.
+        cli_block = cli_descriptions[name].split("```ccg-edges", 1)[1]
+        sc_block = sc_descriptions[name].split("```ccg-edges", 1)[1]
+        assert cli_block == sc_block, (
+            f"ccg-edges block for {name} diverges:\n  CLI: {cli_block!r}\n"
+            f"  Scaffold: {sc_block!r}"
+        )
+
+
+def test_document_is_dual_tracked_in_both_paths():
+    """Documents must trigger both add_entity (long-term, queryable) AND
+    add_message (short-term, extraction fuel) on both paths."""
+    cli_calls = _run_cli_path(_RecordingClient())
+    scaffold_calls = _run_scaffold_path(_RecordingClient())
+
+    def _doc_entity_present(seq):
+        return any(
+            n == "long_term.add_entity" and kw.get("name") == "Discharge Note — Bob"
+            for n, kw in seq
+        )
+
+    def _doc_message_present(seq):
+        return any(
+            n == "short_term.add_message" and kw.get("role") == "document"
+            and (kw.get("metadata") or {}).get("title") == "Discharge Note — Bob"
+            for n, kw in seq
+        )
+
+    assert _doc_entity_present(cli_calls), "CLI path missing Document long_term entity"
+    assert _doc_entity_present(scaffold_calls), "Scaffold path missing Document long_term entity"
+    assert _doc_message_present(cli_calls), "CLI path missing Document short_term message"
+    assert _doc_message_present(scaffold_calls), "Scaffold path missing Document short_term message"
+
+
+def test_body_field_entity_emits_message_in_both_paths():
+    """An entity declared in BODY_FIELDS (Note.body) must trigger an
+    add_message with the body content, on both paths."""
+    cli_calls = _run_cli_path(_RecordingClient())
+    scaffold_calls = _run_scaffold_path(_RecordingClient())
+
+    def _body_message(seq):
+        for n, kw in seq:
+            if n == "short_term.add_message" and (kw.get("metadata") or {}).get("entity_name") == "Note-001":
+                return kw
+        return None
+
+    cli_body = _body_message(cli_calls)
+    sc_body = _body_message(scaffold_calls)
+    assert cli_body is not None, "CLI path: Note body not sent through add_message"
+    assert sc_body is not None, "Scaffold path: Note body not sent through add_message"
+    assert cli_body["content"] == sc_body["content"], (
+        f"Body content diverges:\n  CLI: {cli_body['content']!r}\n  Scaffold: {sc_body['content']!r}"
+    )
+    assert "chest pain" in cli_body["content"]
+
+
+def test_no_relationship_writes_on_nams():
+    """NAMS REST has no add_relationship; both paths must avoid calling it."""
+    cli_calls = _run_cli_path(_RecordingClient())
+    scaffold_calls = _run_scaffold_path(_RecordingClient())
+    assert all(n != "long_term.add_relationship" for n, _ in cli_calls)
+    assert all(n != "long_term.add_relationship" for n, _ in scaffold_calls)

--- a/tests/test_routes_integration.py
+++ b/tests/test_routes_integration.py
@@ -307,6 +307,18 @@ class TestNamsRoutes:
             assert len(body["documents"]) == 1
             assert body["documents"][0]["title"] == "Discharge Note"
 
+    def test_documents_rejects_template_filter_on_nams(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        backend_dir = _scaffold(tmp_path, backend="nams")
+        client = _fake_client()
+        app, _, _ = _import_app(backend_dir, backend="nams", fake_client=client)
+
+        with TestClient(app) as tc:
+            r = tc.get("/api/documents?template_id=discharge")
+            assert r.status_code == 501
+            assert "not supported" in r.json()["detail"]
+
     def test_search_uses_long_term_search(self, tmp_path):
         from fastapi.testclient import TestClient
 

--- a/tests/test_routes_integration.py
+++ b/tests/test_routes_integration.py
@@ -277,20 +277,25 @@ class TestNamsRoutes:
             assert "nams" in body
             assert "neo4j" not in body  # bolt-only field
 
-    def test_documents_uses_short_term_messages(self, tmp_path):
+    def test_documents_uses_long_term_entities(self, tmp_path):
+        """Documents are now dual-tracked on NAMS — the /documents endpoint
+        reads from the long_term Document entity (queryable, matches bolt
+        graph shape) rather than short_term messages (which are extraction
+        fuel, not the source of truth)."""
         from fastapi.testclient import TestClient
 
         backend_dir = _scaffold(tmp_path, backend="nams")
         client = _fake_client()
-        client.short_term.get_conversation = AsyncMock(
-            return_value=SimpleNamespace(
-                messages=[
-                    SimpleNamespace(
-                        content="Discharge content",
-                        metadata={"title": "Discharge Note", "template_id": "discharge"},
-                    ),
-                ]
-            )
+        # The new adapter calls long_term.search_entities and filters to
+        # OBJECT-typed records whose description has a body.
+        client.long_term.search_entities = AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    name="Discharge Note",
+                    entity_type="OBJECT",
+                    description="Discharge content\n\n_pole_type: OBJECT_",
+                ),
+            ]
         )
         app, _, _ = _import_app(backend_dir, backend="nams", fake_client=client)
 


### PR DESCRIPTION
 ## Summary

 - Replace the B-partial NAMS ingest path: entity relationships are now encoded
   into the source entity's `description` as a fenced ```ccg-edges YAML block,
   documents are dual-tracked (`long_term.add_entity(Document)` +
   `short_term.add_message`), and entities declaring `BODY_FIELDS` route their
   body field through `add_message` so NAMS-side extraction sees the prose.
 - Fix runtime `make import` on NAMS scaffolds. The generated
   `import_data.py` now dispatches on `settings.memory_backend`: NAMS uses the
   new write shape (mirrors CLI `ingest.py`); `--self-hosted` keeps native
   Cypher MERGE edges.
 - Idempotency via per-connector watermarks in `.context-graph/watermarks.json`,
   only advanced on clean batches. Failures append to
   `.context-graph/deadletter.jsonl`; `make import-retry` drains it.
 - Frontend `/documents` reads from long_term Document entities (matches bolt
   graph shape); `ccg-edges` and `_pole_type` markers are stripped from
   previews.
 - New `tests/test_nams_ingest_parity.py` snapshot-diffs the NAMS call sequence
   emitted by CLI `ingest.run_nams_ingest` and the rendered scaffold template
   against a shared fixture, so the two duplicated write paths can't drift.

 ## Why ccg-edges encoding

 NAMS REST exposes `add_entity` / `add_message` / `reasoning.*` but not
 `add_relationship`. Connector edges are too valuable to drop, and waiting
 on upstream blocks `make import` indefinitely. The encoding lives entirely
 in `_build_ccg_edges_block` (deterministic sort, distinctive fence marker),
 which is the single seam to replace when NAMS ships the missing endpoint.
 The bolt path is unchanged — it still writes native edges, so self-hosted
 graphs stay query-rich today.

 ## Files of note

 - `src/create_context_graph/ingest.py` — new `run_nams_ingest()` shared by
   CLI + parity test
 - `src/create_context_graph/templates/backend/connectors/import_data.py.j2` —
   rewritten dispatch (NAMS / bolt) with deadletter + watermarks
 - `src/create_context_graph/templates/backend/shared/memory_adapter.py.j2` —
   `ingest_fixtures_nams` mirrors new shape; `/documents` reads long_term
 - `src/create_context_graph/connectors/__init__.py` — `BODY_FIELDS` on
   `BaseConnector` (populated on Linear, GWS, local-file, Claude Code,
   Claude AI, ChatGPT)
 - `tests/test_nams_ingest_parity.py` — call-capture contract test
 - `docs/docs/how-to/use-nams.md` — documents the encoding + migration path

 ## Test plan

 - [ ] CI green (`pytest tests/ --ignore=tests/test_performance.py --ignore=tests/test_generated_tests.py --ignore=tests/test_matrix.py` — local: 1244 passed, 10 skipped)
 - [ ] `ruff check src/ tests/` clean
 - [ ] Smoke-test scaffold against NAMS:
   - `uvx . my-app --domain healthcare --framework strands --nams-api-key $MEMORY_API_KEY --connector linear --demo-data`
   - `cd my-app && make import` → confirm no exceptions, `.context-graph/watermarks.json` written
   - re-run `make import` immediately → confirm watermark prevents re-fetch, no duplicate writes
   - open the chat UI, ask about a Linear issue → confirm `ccg-edges` content reaches the agent
 - [ ] Smoke-test scaffold against bolt (`--self-hosted`) → confirm native edges land via MERGE, no `ccg-edges` blocks in descriptions
 - [ ] Verify deadletter path: stop the NAMS endpoint mid-import, confirm failed records land in `.context-graph/deadletter.jsonl`, restart, `make import-retry` drains it

 ## Follow-ups (not in this PR)

 - Migration to native edges once `neo4j-agent-memory` exposes
   `add_relationship`: parse `ccg-edges` blocks from existing descriptions
   and replay as native edges. Touchpoint is `_build_ccg_edges_block`; the
   parity test is the safety net.
 - Lift `BODY_FIELDS` into the remaining connectors (GitHub, Notion, Jira,
   Slack, Gmail, Salesforce) as they grow body-bearing entities.