### PR TITLE
Fix custom domain resolution in load_domain (#30)

### DIFF
--- a/src/create_context_graph/ontology.py
+++ b/src/create_context_graph/ontology.py
@@ -236,28 +236,59 @@ def _merge_base(base: dict, domain_data: dict) -> dict:
     return domain_data
 
 
-def load_domain(domain_id: str) -> DomainOntology:
-    """Load a domain ontology by ID, merging with base definitions."""
-    domains_dir = _get_domains_path()
-    domain_path = domains_dir / f"{domain_id}.yaml"
+def _find_domain_path(domain_id: str) -> Path | None:
+    """Locate a domain YAML by id, searching bundled then custom domains.
 
-    if not domain_path.exists():
+    Resolution order mirrors ``list_available_domains()`` so that any domain
+    advertised in the available list can actually be loaded:
+
+      1. Bundled domains directory   (<pkg>/domains/<id>.yaml)
+      2. User custom domains         (~/.create-context-graph/custom-domains/<id>.yaml)
+
+    For custom domains we also fall back to matching the declared
+    ``domain.id`` field, since a saved file's stem can drift from the id it
+    declares internally (and ``list_available_domains`` keys off ``domain.id``).
+
+    Returns the resolved Path, or None if no match is found.
+    """
+    # Fast path: direct filename match in either directory.
+    for domains_dir in (_get_domains_path(), _get_custom_domains_path()):
+        candidate = domains_dir / f"{domain_id}.yaml"
+        if candidate.exists():
+            return candidate
+
+    # Fallback: scan custom domains and match on the declared domain.id.
+    custom_dir = _get_custom_domains_path()
+    if custom_dir.exists():
+        for path in sorted(custom_dir.glob("*.yaml")):
+            if path.stem.startswith("_"):
+                continue
+            try:
+                with open(path) as f:
+                    data = yaml.safe_load(f) or {}
+            except Exception:
+                continue
+            if isinstance(data, dict) and data.get("domain", {}).get("id") == domain_id:
+                return path
+
+    return None
+
+
+def load_domain(domain_id: str) -> DomainOntology:
+    """Load a domain ontology by ID, merging with base definitions.
+
+    Searches both the bundled domains directory and the user-local custom
+    domains directory (``~/.create-context-graph/custom-domains/``), so
+    domains created via the custom-domain wizard resolve the same way the
+    bundled ones do. This keeps loading consistent with
+    ``list_available_domains()``, which already scans both locations.
+    """
+    domain_path = _find_domain_path(domain_id)
+
+    if domain_path is None:
         raise FileNotFoundError(f"Domain ontology not found: {domain_id}")
 
-    with open(domain_path) as f:
-        data = yaml.safe_load(f)
-
-    # Merge base if domain declares inheritance
-    if data.get("inherits") == "_base" or data.get("domain", {}).get("inherits") == "_base":
-        base = _load_base()
-        data = _merge_base(base, data)
-
-    # Remove the inherits key before parsing
-    data.pop("inherits", None)
-    if "domain" in data and isinstance(data["domain"], dict):
-        data["domain"].pop("inherits", None)
-
-    return DomainOntology.model_validate(data)
+    return load_domain_from_path(domain_path)
 
 
 def load_domain_from_yaml_string(yaml_content: str) -> DomainOntology:

--- a/tests/test_custom_domain.py
+++ b/tests/test_custom_domain.py
@@ -32,6 +32,7 @@ from create_context_graph.custom_domain import (
 from create_context_graph.ontology import (
     DomainOntology,
     list_available_domains,
+    load_domain,
     load_domain_from_yaml_string,
 )
 
@@ -479,3 +480,86 @@ class TestDisplayAndSave:
             domains = list_available_domains()
             ids = [d["id"] for d in domains]
             assert "test-domain" in ids
+
+
+class TestLoadCustomDomainResolution:
+    """Regression tests for issue #30.
+
+    Custom domains were saved and shown in ``list_available_domains()`` but
+    ``load_domain()`` only searched the bundled domains directory, so any
+    custom domain failed to resolve with "Domain not found" — even though it
+    appeared in the very "Available domains" list printed alongside the error.
+    """
+
+    def test_load_saved_custom_domain_by_id(self, tmp_path):
+        """A saved custom domain resolves by its id (the core bug)."""
+        custom_dir = tmp_path / "custom-domains"
+        custom_dir.mkdir()
+        (custom_dir / "test-domain.yaml").write_text(VALID_DOMAIN_YAML)
+
+        with patch(
+            "create_context_graph.ontology._get_custom_domains_path",
+            return_value=custom_dir,
+        ):
+            ont = load_domain("test-domain")
+
+        assert isinstance(ont, DomainOntology)
+        assert ont.domain.id == "test-domain"
+
+    def test_every_listed_domain_is_loadable(self, tmp_path):
+        """The exact contradiction from the issue: anything advertised in
+        list_available_domains() must actually load."""
+        custom_dir = tmp_path / "custom-domains"
+        custom_dir.mkdir()
+        (custom_dir / "test-domain.yaml").write_text(VALID_DOMAIN_YAML)
+
+        with patch(
+            "create_context_graph.ontology._get_custom_domains_path",
+            return_value=custom_dir,
+        ):
+            for d in list_available_domains():
+                # Must not raise FileNotFoundError for any advertised domain.
+                ont = load_domain(d["id"])
+                assert ont.domain.id == d["id"]
+
+    def test_load_custom_domain_matches_internal_id_when_stem_differs(self, tmp_path):
+        """Resolution falls back to the declared domain.id when the saved
+        file's stem has drifted from the id it declares."""
+        custom_dir = tmp_path / "custom-domains"
+        custom_dir.mkdir()
+        (custom_dir / "some-other-filename.yaml").write_text(VALID_DOMAIN_YAML)
+
+        with patch(
+            "create_context_graph.ontology._get_custom_domains_path",
+            return_value=custom_dir,
+        ):
+            ont = load_domain("test-domain")
+
+        assert ont.domain.id == "test-domain"
+
+    def test_custom_domain_inherits_base_entities(self, tmp_path):
+        """A loaded custom domain still merges the base POLE+O entities."""
+        custom_dir = tmp_path / "custom-domains"
+        custom_dir.mkdir()
+        (custom_dir / "test-domain.yaml").write_text(VALID_DOMAIN_YAML)
+
+        with patch(
+            "create_context_graph.ontology._get_custom_domains_path",
+            return_value=custom_dir,
+        ):
+            ont = load_domain("test-domain")
+
+        labels = {et.label for et in ont.entity_types}
+        assert "Person" in labels
+
+    def test_missing_domain_still_raises(self, tmp_path):
+        """Genuinely unknown domains still raise FileNotFoundError."""
+        custom_dir = tmp_path / "custom-domains"
+        custom_dir.mkdir()
+
+        with patch(
+            "create_context_graph.ontology._get_custom_domains_path",
+            return_value=custom_dir,
+        ):
+            with pytest.raises(FileNotFoundError):
+                load_domain("does-not-exist-anywhere")


### PR DESCRIPTION
Closes #30.

## Problem
`list_available_domains()` scans both the bundled domains directory and `~/.create-context-graph/custom-domains/`, but `load_domain()` only searched the bundled directory. Saved custom domains therefore appeared in the 'Available domains' list yet failed to load with 'Domain not found' — affecting both the `--domain` CLI flag and selecting a saved custom domain in the wizard.

## Fix
Added `_find_domain_path()`, which resolves a domain id against bundled then custom directories, with a fallback that matches the YAML's internal `domain.id` when a saved file's stem has drifted. `load_domain()` now delegates to the existing `load_domain_from_path()` so the base-inheritance merge isn't duplicated.

## Tests
Added `TestLoadCustomDomainResolution` (5 tests), including one asserting every domain in `list_available_domains()` is loadable. No regressions across test_ontology.py and test_custom_domain.py.