### PR TITLE
Handle NAMS cypher execution and connection guard

### DIFF
--- a/src/create_context_graph/templates/backend/shared/context_graph_client.py.j2
+++ b/src/create_context_graph/templates/backend/shared/context_graph_client.py.j2
@@ -201,6 +201,55 @@ def get_driver() -> AsyncDriver:
     return _driver
 
 
+def _coerce_nams_records(raw):
+    """Normalize results from the NAMS cypher API into a list of row objects."""
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        for key in ("results", "data", "rows"):
+            value = raw.get(key)
+            if isinstance(value, list):
+                return value
+            if value is not None and isinstance(value, tuple):
+                return list(value)
+        return [raw]
+    if isinstance(raw, tuple):
+        return list(raw)
+    return [raw]
+
+
+async def _execute_nams_cypher(
+    query: str,
+    parameters: dict | None = None,
+    *,
+    collect: bool = True,
+    tool_name: str | None = None,
+    timeout: float | None = 30.0,
+) -> list[dict]:
+    """Execute a read-only cypher query using the NAMS client."""
+    del timeout  # Kept for call compatibility
+    from app.memory import get_client
+
+    client = get_client()
+    if client is None:
+        raise RuntimeError("NAMS client not connected. Call connect_memory() first.")
+
+    params = parameters or {}
+    if tool_name and collect:
+        _collector.emit_tool_start(tool_name, params)
+
+    result = await client.query.cypher(query, params)
+    records = _coerce_nams_records(result)
+
+    if collect:
+        _collector.collect(records)
+        if tool_name:
+            _collector.collect_tool_call(tool_name, params, str(records[:2]))
+    return records
+
+
 async def execute_cypher(
     query: str,
     parameters: dict | None = None,
@@ -210,6 +259,17 @@ async def execute_cypher(
     timeout: float | None = 30.0,
 ) -> list[dict]:
     """Execute a Cypher query and return results as dicts with graph metadata."""
+    from app.config import settings
+
+    if settings.memory_backend == "nams":
+        return await _execute_nams_cypher(
+            query,
+            parameters,
+            collect=collect,
+            tool_name=tool_name,
+            timeout=timeout,
+        )
+
     driver = get_driver()
     if tool_name and collect:
         _collector.emit_tool_start(tool_name, parameters or {})

--- a/src/create_context_graph/templates/backend/shared/routes.py.j2
+++ b/src/create_context_graph/templates/backend/shared/routes.py.j2
@@ -47,6 +47,13 @@ def _require_neo4j():
     surface their own errors at the adapter level.
     """
     if _is_nams():
+        from app.memory import get_client
+
+        if get_client() is None:
+            raise HTTPException(
+                status_code=503,
+                detail="NAMS client not connected. Check MEMORY_API_KEY and restart.",
+            )
         return
     if not is_connected():
         raise HTTPException(
@@ -271,20 +278,15 @@ async def cypher(request: CypherRequest):
     On NAMS, only read queries are accepted (server enforces).
     """
     _require_neo4j()
+    params = dict(request.parameters or {})
     if _is_nams():
-        from app.memory import get_client
-        client = get_client()
-        if client is None:
-            raise HTTPException(status_code=503, detail="NAMS client not connected")
         try:
-            params = dict(request.parameters or {})
-            results = await client.query.cypher(request.query, params)
+            results = await execute_cypher(request.query, params, collect=True)
             return {"results": results}
         except Exception as e:
             raise HTTPException(status_code=400, detail=str(e))
+    params.setdefault("domain", settings.domain_id)
     try:
-        params = dict(request.parameters or {})
-        params.setdefault("domain", settings.domain_id)
         results = await execute_cypher(request.query, params)
         return {"results": results}
     except Exception as e:


### PR DESCRIPTION
## Summary
- Add NAMS execution path to context_graph_client.py template execute_cypher with record-shape normalization and client checks.
- Update _require_neo4j() in routes template to validate NAMS client instead of skipping when backend is NAMS.
- Use execute_cypher for NAMS /cypher endpoint to keep response normalization/collection consistent.

## Why
Prevents connection errors when running with NAMS backend (`settings.memory_backend == "nams"`) while keeping existing Neo4j path unchanged.

## Issue
Fixes #55
