### PR TITLE
Wire up --ontology-file (documented, never implemented)

### DIFF
--- a/src/create_context_graph/cli.py
+++ b/src/create_context_graph/cli.py
@@ -134,6 +134,11 @@ def _run_import_preview(
     help="Domain ID (e.g., financial-services, healthcare, software-engineering)",
 )
 @click.option(
+    "--ontology-file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to a hand-written domain ontology YAML file to use directly (bypasses --domain and --custom-domain)",
+)
+@click.option(
     "--framework",
     type=click.Choice(SUPPORTED_FRAMEWORKS, case_sensitive=False),
     help="Agent framework to use",
@@ -199,6 +204,7 @@ def _run_import_preview(
 def main(
     project_name: str | None,
     domain: str | None,
+    ontology_file: str | None,
     framework: str | None,
     demo_data: bool,
     ingest: bool,
@@ -337,6 +343,15 @@ def main(
             raise SystemExit(1)
 
         display_ontology_summary(custom_ontology, console)
+        domain = custom_ontology.domain.id
+    elif ontology_file:
+        from create_context_graph.ontology import load_domain_from_path
+
+        try:
+            custom_ontology = load_domain_from_path(Path(ontology_file))
+        except Exception as e:
+            console.print(f"[red]Error:[/red] Failed to load ontology file '{ontology_file}': {e}")
+            raise SystemExit(1)
         domain = custom_ontology.domain.id
 
     # Handle Neo4j Aura .env import


### PR DESCRIPTION
## Summary

- `--ontology-file` is documented in `docs/docs/how-to/add-custom-domain.md` and tracked as #50, but `cli.py` had no code path calling it. `load_domain_from_path()` already existed in `ontology.py`, it just wasn't wired into `main()`.
- Adds the flag and wires it in the same way the existing `--custom-domain` (LLM-generation) path already does, so `--ontology-file /path/to/domain.yaml` scaffolds directly from a hand-written ontology without going through `--domain` or an LLM call.

Closes #50.

## Test plan

- [x] Fresh scaffold generated with `--ontology-file` pointed at a real hand-written domain YAML, output inspected directly.
- [x] Full existing test suite passes with no regressions.