### PR TITLE
Fix demo_scenarios[0] crash when demo_scenarios is omitted

### DIFF
--- a/src/create_context_graph/templates/frontend/e2e/app.spec.ts.j2
+++ b/src/create_context_graph/templates/frontend/e2e/app.spec.ts.j2
@@ -135,7 +135,7 @@ test.describe("{{ domain.name }} Context Graph", () => {
 
     // Send a prompt that should trigger tool calls
     const input = page.getByPlaceholder(/ask about/i);
-    await input.fill({{ demo_scenarios[0].prompts[0] | tojson }});
+    await input.fill({{ (demo_scenarios[0].prompts[0] if demo_scenarios else 'Show me the data in the graph') | tojson }});
     await page.getByRole("button", { name: /send/i }).click();
 
     // Wait for at least one tool call badge to appear
@@ -155,7 +155,7 @@ test.describe("{{ domain.name }} Context Graph", () => {
 
     // Send a query that should return graph data
     const input = page.getByPlaceholder(/ask about/i);
-    await input.fill({{ demo_scenarios[0].prompts[0] | tojson }});
+    await input.fill({{ (demo_scenarios[0].prompts[0] if demo_scenarios else 'Show me the data in the graph') | tojson }});
     await page.getByRole("button", { name: /send/i }).click();
 
     // Wait for the graph to switch from schema to data view


### PR DESCRIPTION
## Summary

- `demo_scenarios` is documented as optional, but `templates/frontend/e2e/app.spec.ts.j2` indexed `demo_scenarios[0].prompts[0]` unconditionally in two places, crashing the entire scaffold generation (not just the frontend template) for any domain that omits it.
- Falls back to a generic prompt ("Show me the data in the graph") when the list is empty.

## Test plan

- [x] Fresh scaffold generated from a domain with no `demo_scenarios` defined, no longer crashes.
- [x] Full existing test suite passes with no regressions.