### PR TITLE
Fix self-hosted bolt backend ignoring non-default Neo4j database name -- i.e. Aura Free

### DIFF
--- a/src/create_context_graph/cli.py
+++ b/src/create_context_graph/cli.py
@@ -148,6 +148,7 @@ def _run_import_preview(
 @click.option("--neo4j-uri", envvar="NEO4J_URI", help="Neo4j connection URI (--self-hosted only)")
 @click.option("--neo4j-username", envvar="NEO4J_USERNAME", default="neo4j")
 @click.option("--neo4j-password", envvar="NEO4J_PASSWORD", default="password")
+@click.option("--neo4j-database", envvar="NEO4J_DATABASE", default="", help="Neo4j database name (--self-hosted only; defaults to 'neo4j' if unset — override for Aura instances whose database isn't named 'neo4j')")
 @click.option("--neo4j-aura-env", type=click.Path(exists=True), help="Path to Neo4j Aura .env file with credentials (--self-hosted only)")
 @click.option("--neo4j-local", is_flag=True, help="Use @johnymontana/neo4j-local for local Neo4j (--self-hosted only)")
 @click.option("--anthropic-api-key", envvar="ANTHROPIC_API_KEY", help="Anthropic API key for LLM generation")
@@ -210,6 +211,7 @@ def main(
     neo4j_uri: str | None,
     neo4j_username: str,
     neo4j_password: str,
+    neo4j_database: str,
     neo4j_aura_env: str | None,
     neo4j_local: bool,
     anthropic_api_key: str | None,
@@ -342,7 +344,9 @@ def main(
     # Handle Neo4j Aura .env import
     if neo4j_aura_env:
         from create_context_graph.wizard import _parse_aura_env
-        neo4j_uri, neo4j_username, neo4j_password = _parse_aura_env(neo4j_aura_env)
+        neo4j_uri, neo4j_username, neo4j_password, aura_database = _parse_aura_env(neo4j_aura_env)
+        # --neo4j-database (if explicitly passed) wins over the aura .env file
+        neo4j_database = neo4j_database or aura_database
 
     # Determine memory backend. Default is NAMS unless --self-hosted is set,
     # any --neo4j-* override is explicitly passed, or NAMS key is absent in
@@ -411,6 +415,7 @@ def main(
             neo4j_uri=neo4j_uri or "neo4j://localhost:7687",
             neo4j_username=neo4j_username,
             neo4j_password=neo4j_password,
+            neo4j_database=neo4j_database,
             neo4j_type=neo4j_type_resolved,
             anthropic_api_key=anthropic_api_key,
             openai_api_key=openai_api_key,
@@ -518,7 +523,8 @@ def main(
         console.print(f"  Framework:  {config.framework}")
         console.print(f"  Backend:    {config.memory_backend}")
         if config.is_self_hosted:
-            console.print(f"  Neo4j:      {config.neo4j_type} ({config.neo4j_uri})")
+            db_suffix = f", database={config.neo4j_database}" if config.neo4j_database else ""
+            console.print(f"  Neo4j:      {config.neo4j_type} ({config.neo4j_uri}{db_suffix})")
         else:
             console.print(f"  NAMS:       {config.nams_endpoint}")
         console.print(f"  Data:       {config.data_source}")

--- a/src/create_context_graph/config.py
+++ b/src/create_context_graph/config.py
@@ -84,6 +84,11 @@ class ProjectConfig(BaseModel):
     neo4j_uri: str = Field(default="neo4j://localhost:7687")
     neo4j_username: str = Field(default="neo4j")
     neo4j_password: str = Field(default="password")
+    # "" defers to neo4j-agent-memory's own default ("neo4j"). Must be set
+    # explicitly for Aura instances whose database isn't named "neo4j" (e.g.
+    # ones provisioned via the Aura API/CLI, which commonly name it after
+    # the instance id).
+    neo4j_database: str = Field(default="")
     neo4j_type: Literal["docker", "existing", "aura", "local"] = Field(default="docker")
 
     anthropic_api_key: str | None = Field(default=None)

--- a/src/create_context_graph/renderer.py
+++ b/src/create_context_graph/renderer.py
@@ -263,6 +263,7 @@ class ProjectRenderer:
             "neo4j_uri": self.config.neo4j_uri,
             "neo4j_username": self.config.neo4j_username,
             "neo4j_password": self.config.neo4j_password,
+            "neo4j_database": self.config.neo4j_database,
             "neo4j_type": self.config.neo4j_type,
             "anthropic_api_key": self.config.anthropic_api_key or "",
             "openai_api_key": self.config.openai_api_key or "",

--- a/src/create_context_graph/templates/backend/shared/config.py.j2
+++ b/src/create_context_graph/templates/backend/shared/config.py.j2
@@ -26,6 +26,9 @@ class Settings(BaseSettings):
     neo4j_uri: str = ""
     neo4j_username: str = ""
     neo4j_password: str = ""
+    # "" defers to neo4j-agent-memory's own default ("neo4j"). Override for
+    # instances whose database isn't literally named "neo4j".
+    neo4j_database: str = ""
 
     # LiteLLM provider strings for memory layer (optional — sane defaults applied)
     memory_llm: str = "{{ memory_llm }}"

--- a/src/create_context_graph/templates/backend/shared/context_graph_client.py.j2
+++ b/src/create_context_graph/templates/backend/shared/context_graph_client.py.j2
@@ -210,10 +210,12 @@ async def execute_cypher(
     timeout: float | None = 30.0,
 ) -> list[dict]:
     """Execute a Cypher query and return results as dicts with graph metadata."""
+    from app.config import settings
+
     driver = get_driver()
     if tool_name and collect:
         _collector.emit_tool_start(tool_name, parameters or {})
-    async with driver.session() as session:
+    async with driver.session(database=settings.neo4j_database or None) as session:
         result = await session.run(query, parameters or {}, timeout=timeout)
         records = []
         async for record in result:

--- a/src/create_context_graph/templates/backend/shared/main.py.j2
+++ b/src/create_context_graph/templates/backend/shared/main.py.j2
@@ -54,8 +54,14 @@ async def lifespan(app: FastAPI):
         try:
             await connect_neo4j()
             _neo4j_available = True
-            _memory_available = True
-            logger.info("Neo4j connected successfully")
+            # connect_neo4j() calls connect_memory() internally, which catches
+            # its own exceptions — check the client rather than assuming success.
+            _memory_available = get_client() is not None
+            if _memory_available:
+                logger.info("Neo4j connected successfully")
+            else:
+                detail = get_error_detail() or "memory integration unavailable"
+                logger.warning("Neo4j connected but memory is degraded: %s", detail)
         except Exception as e:
             _neo4j_available = False
             _memory_available = False
@@ -134,10 +140,20 @@ async def health():
             body["nams_dashboard"] = "https://memory.neo4jlabs.com"
         return body
     neo4j_ok = is_connected()
-    return {
-        "status": "ok" if neo4j_ok else "degraded",
+    # get_error_category() reflects the LATEST failure, including ones
+    # recorded by store_message() after a successful startup connect —
+    # get_memory_status() alone is a stale startup-time snapshot.
+    category = get_error_category()
+    memory_ok = get_memory_status() and category is None
+    body = {
+        "status": "ok" if (neo4j_ok and memory_ok) else "degraded",
         "memory_backend": "bolt",
         "neo4j": neo4j_ok,
+        "memory": memory_ok,
         "domain": "{{ domain.id }}",
         "version": "0.1.0",
     }
+    if neo4j_ok and category:
+        body["memory_error"] = category
+        body["memory_error_detail"] = get_error_detail()
+    return body

--- a/src/create_context_graph/templates/backend/shared/memory.py.j2
+++ b/src/create_context_graph/templates/backend/shared/memory.py.j2
@@ -151,12 +151,16 @@ def _build_memory_settings():
             **common,
         )
 
+    neo4j_config: dict = {
+        "uri": settings.neo4j_uri,
+        "username": settings.neo4j_username,
+        "password": SecretStr(settings.neo4j_password),
+    }
+    if settings.neo4j_database:
+        neo4j_config["database"] = settings.neo4j_database
+
     return MemorySettings(
-        neo4j={
-            "uri": settings.neo4j_uri,
-            "username": settings.neo4j_username,
-            "password": SecretStr(settings.neo4j_password),
-        },
+        neo4j=neo4j_config,
         **common,
     )
 
@@ -281,7 +285,12 @@ async def store_message(session_id: str, role: str, content: str) -> dict | None
     Catches ``NotSupportedError`` for cases where the active backend (e.g. NAMS)
     doesn't expose certain extraction sub-features — extracted entities still
     persist where possible.
+
+    Records failures into the same ``_error_category``/``_error_detail`` state
+    ``connect_memory()`` uses, so ``get_error_category()``/``get_error_message()``
+    reflect live write failures too — not just failures at startup connect time.
     """
+    global _error_category, _error_detail
     if _memory is None:
         return None
     try:
@@ -289,12 +298,16 @@ async def store_message(session_id: str, role: str, content: str) -> dict | None
     except ImportError:
         NotSupportedError = Exception  # type: ignore[assignment, misc]
     try:
-        return await _memory.store_message(role, content, session_id=session_id)
+        result = await _memory.store_message(role, content, session_id=session_id)
+        _error_category = None
+        _error_detail = None
+        return result
     except NotSupportedError as e:
         logger.info("Partial store on %s backend: %s", settings.memory_backend, e)
         return None
     except Exception as e:
-        logger.warning("Failed to store message: %s", e)
+        _error_category, _error_detail = _classify_memory_error(e)
+        logger.warning("Failed to store message [%s/%s]: %s", _error_category, _error_detail, e)
         return None
 
 

--- a/src/create_context_graph/templates/base/dot_env.j2
+++ b/src/create_context_graph/templates/base/dot_env.j2
@@ -13,6 +13,10 @@ MEMORY_API_KEY={{ nams_api_key }}
 NEO4J_URI={{ neo4j_uri }}
 NEO4J_USERNAME={{ neo4j_username }}
 NEO4J_PASSWORD={{ neo4j_password }}
+# Database name. Leave blank to use the SDK default ("neo4j") — override this
+# if your instance's database has a different name (e.g. Aura instances
+# provisioned via the Aura API/CLI often name it after the instance id).
+NEO4J_DATABASE={{ neo4j_database }}
 {% endif %}
 
 # Memory layer LLM + embedding provider (LiteLLM-style strings, optional)

--- a/src/create_context_graph/wizard.py
+++ b/src/create_context_graph/wizard.py
@@ -50,8 +50,14 @@ from create_context_graph.ontology import list_available_domains
 console = Console()
 
 
-def _parse_aura_env(env_path: str) -> tuple[str, str, str]:
-    """Parse a Neo4j Aura .env file and return (uri, username, password)."""
+def _parse_aura_env(env_path: str) -> tuple[str, str, str, str]:
+    """Parse a Neo4j Aura .env file and return (uri, username, password, database).
+
+    ``database`` is read from ``NEO4J_DATABASE`` if present, else "" — Aura
+    instances provisioned via the Aura API/CLI commonly name their database
+    after the instance id rather than the literal string "neo4j", so this
+    must be read explicitly rather than assumed.
+    """
     from pathlib import Path
 
     path = Path(env_path).expanduser()
@@ -71,6 +77,7 @@ def _parse_aura_env(env_path: str) -> tuple[str, str, str]:
     uri = values.get("NEO4J_URI", "")
     username = values.get("NEO4J_USERNAME", "neo4j")
     password = values.get("NEO4J_PASSWORD", "")
+    database = values.get("NEO4J_DATABASE", "")
 
     if not uri:
         console.print("[red]Error:[/red] NEO4J_URI not found in .env file")
@@ -80,7 +87,7 @@ def _parse_aura_env(env_path: str) -> tuple[str, str, str]:
         raise SystemExit(1)
 
     console.print(f"  [green]✓[/green] Loaded credentials for {uri}")
-    return uri, username, password
+    return uri, username, password, database
 
 
 def _banner() -> None:
@@ -254,8 +261,8 @@ def _prompt_nams_api_key() -> str:
     return key
 
 
-def _prompt_self_hosted_neo4j() -> tuple[str, str, str, str]:
-    """Returns (uri, username, password, neo4j_type) for the bolt path."""
+def _prompt_self_hosted_neo4j() -> tuple[str, str, str, str, str]:
+    """Returns (uri, username, password, database, neo4j_type) for the bolt path."""
     neo4j_type = _ask_or_abort(
         questionary.select(
             "How would you like to connect to Neo4j?",
@@ -285,15 +292,15 @@ def _prompt_self_hosted_neo4j() -> tuple[str, str, str, str]:
             questionary.path("Path to Neo4j Aura .env file:").ask(),
             "Aura .env",
         )
-        uri, username, password = _parse_aura_env(aura_env_path)
+        uri, username, password, database = _parse_aura_env(aura_env_path)
     elif neo4j_type == "local":
-        uri, username, password = "neo4j://localhost:7687", "neo4j", "password"
+        uri, username, password, database = "neo4j://localhost:7687", "neo4j", "password", ""
         console.print(
             "[dim]Will use [bold]@johnymontana/neo4j-local[/bold] — "
             "run [bold]make neo4j-start[/bold] to launch Neo4j (requires Node.js)[/dim]"
         )
     elif neo4j_type == "docker":
-        uri, username, password = "neo4j://localhost:7687", "neo4j", "password"
+        uri, username, password, database = "neo4j://localhost:7687", "neo4j", "password", ""
     else:
         uri = _ask_or_abort(
             questionary.text("Neo4j URI:", default="neo4j+s://xxxx.databases.neo4j.io").ask(),
@@ -304,8 +311,14 @@ def _prompt_self_hosted_neo4j() -> tuple[str, str, str, str]:
             "neo4j username",
         )
         password = _ask_or_abort(questionary.password("Neo4j Password:").ask(), "neo4j password")
+        database = _ask_or_abort(
+            questionary.text(
+                "Neo4j Database name (leave blank for default 'neo4j'):", default=""
+            ).ask(),
+            "neo4j database",
+        )
 
-    return uri, username, password, neo4j_type
+    return uri, username, password, database, neo4j_type
 
 
 def _prompt_session_strategy() -> str:
@@ -502,9 +515,10 @@ def run_wizard(*, self_hosted: bool = False) -> ProjectConfig:
     neo4j_uri = "neo4j://localhost:7687"
     neo4j_username = "neo4j"
     neo4j_password = "password"
+    neo4j_database = ""
     neo4j_type = "docker"
     if self_hosted:
-        neo4j_uri, neo4j_username, neo4j_password, neo4j_type = (
+        neo4j_uri, neo4j_username, neo4j_password, neo4j_database, neo4j_type = (
             _prompt_self_hosted_neo4j()
         )
     else:
@@ -527,6 +541,7 @@ def run_wizard(*, self_hosted: bool = False) -> ProjectConfig:
         neo4j_uri=neo4j_uri,
         neo4j_username=neo4j_username,
         neo4j_password=neo4j_password,
+        neo4j_database=neo4j_database,
         neo4j_type=neo4j_type,
         anthropic_api_key=advanced["anthropic_api_key"] or custom_anthropic_key,
         openai_api_key=advanced["openai_api_key"],

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -192,6 +192,7 @@ class TestSelfHostedPath:
                 "x",                          # project name
                 "neo4j+s://abc.databases.neo4j.io",  # neo4j uri
                 "myuser",                     # username
+                "mydatabase",                 # database name
             ],
             autocomplete=["Software Engineering"],
             select=[
@@ -213,6 +214,7 @@ class TestSelfHostedPath:
         assert cfg.neo4j_uri == "neo4j+s://abc.databases.neo4j.io"
         assert cfg.neo4j_username == "myuser"
         assert cfg.neo4j_password == "secret123"
+        assert cfg.neo4j_database == "mydatabase"
 
 
 class TestQuestionaryConstruction:

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,7 @@ toml = [
 
 [[package]]
 name = "create-context-graph"
-version = "0.11.2"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Add `NEO4J_DATABASE` support for the self-hosted (bolt) backend, threaded end-to-end through the CLI, wizard, generated project, and runtime — plus surface memory-layer failures that were previously swallowed silently.

## Why

`neo4j-agent-memory`'s bolt client defaults to database name `"neo4j"`, and create-context-graph had no way to override it. Any self-hosted instance whose database isn't literally named `"neo4j"` (e.g. Aura instances provisioned via the Aura API/CLI, which commonly name the database after the instance id) fails silently: the app starts, the chat UI works normally, but every memory write fails underneath it — `MemoryClient.connect()` only checks general server connectivity, and `store_message()` caught and swallowed the resulting error with just a log line.

## Changes

- **CLI**: new `--neo4j-database` / `NEO4J_DATABASE` option, including when importing credentials via `--neo4j-aura-env` (previously, `NEO4J_DATABASE` in an imported Aura `.env` file was read and silently discarded).
- **Wizard**: prompts for a database name when entering Neo4j credentials manually, and picks it up from an imported Aura `.env` file.
- **Generated project**: `.env` now includes `NEO4J_DATABASE`; the generated app's `Settings` gains a `neo4j_database` field; `_build_memory_settings()` passes it through to `MemorySettings` when set; the raw driver session in `execute_cypher()` uses the same value, so the memory client and the raw Cypher path stay consistent with each other.
- **Error visibility**: `store_message()` now records failures into the same error state (`get_error_category()` / `get_error_detail()`) used at startup connect time, instead of only logging. The app's startup lifecycle and `/health` endpoint now reflect actual memory-layer connection state on the bolt backend, instead of assuming success as soon as the raw Neo4j driver is reachable.

## Testing

- `make test` — 1337 passed; no new failures (14 pre-existing failures tied to `football-intelligence` domain data, confirmed present on `main` independent of this change).
- `make test-matrix` — 216/224 passed, exercising `--self-hosted` across every domain × framework combination; remaining 8 failures are the same pre-existing `football-intelligence` issue.
- `make smoke-render-bolt` / `make smoke-render-nams` — both pass.
- Verified live against a real Aura instance whose database is not named `"neo4j"`: messages and reasoning traces now store and chain correctly (`HAS_MESSAGE` / `NEXT_MESSAGE` / `FIRST_MESSAGE`, `HAS_STEP` / `USES_TOOL`), where they previously failed with `database 'neo4j' does not exist`.